### PR TITLE
Do not add --jar if JAR_PATH is empty

### DIFF
--- a/lib/node/closure-compiler.js
+++ b/lib/node/closure-compiler.js
@@ -36,7 +36,9 @@ var contribPath = path.dirname(compilerPath) + '/contrib';
 function Compiler(args, extraCommandArgs) {
   this.commandArguments = (extraCommandArgs || []).slice();
 
-  this.commandArguments.push('-jar', Compiler.JAR_PATH);
+  if (Compiler.JAR_PATH) {
+    this.commandArguments.push('-jar', Compiler.JAR_PATH);
+  }
 
   if (Array.isArray(args)) {
     this.commandArguments = this.commandArguments.concat(args.slice());


### PR DESCRIPTION
This PR has come out of the suggestion to investigate nailgun https://github.com/google/closure-compiler/issues/2186

fast-closure-compiler passes the arguments to a python script which in turn passes it to the nailgun server. `-jar` gets passed all the way down to the closure compiler, resulting in this error:
```
"-jar" is not a valid option
```

Therefore, I suggest to not add `-jar` if `JAR_PATH` is falsy. Library consumers like me then have a switch to extend this libraries' functionality to work with nailgun.