### PR TITLE
Support Node v4, v6 and v8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 node_js:
-- '7'
+- '8'
 - '6'
+- '4'
 branches:
   only:
   - master

--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
     "pretest": "./build_compiler.js"
   },
   "engines": {
-    "node": ">=6"
+    "node": ">=4"
   }
 }


### PR DESCRIPTION
Support all maintained versions.

https://github.com/google/closure-compiler-npm/commit/2cd5e0a8d10e7a243229e0928c55227531dc95df dropped v4, but the comment

> Drop node 4 support as it no longer is maintained.

is wrong. v4 is maintained by April 2018 as LTS.
https://github.com/nodejs/LTS

Also test in v8 instead of v7.