### PR TITLE
Add bin wrapper for easier cli use

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+'use strict'
+const spawnSync = require('child_process').spawnSync
+const COMPILER_PATH = require('./index.js').compiler.COMPILER_PATH
+const result = spawnSync(
+  'java',
+  ['-jar', COMPILER_PATH].concat(process.argv.slice(2)),
+  {stdio: 'inherit'}
+)
+if (result.error) {
+  if (result.error.code === 'ENOENT') {
+    console.error('Could not find "java" in your PATH.')
+  } else {
+    console.error(result.error.message)
+  }
+  process.exit(1)
+} else {
+  process.exit(result.status)
+}
+

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "gulpplugin",
     "gruntplugin"
   ],
+  "bin": {
+    "google-closure-compiler": "cli.js"
+  },
   "main": "index.js",
   "contributors": [
     {
@@ -25,6 +28,7 @@
   "files": [
     "lib/",
     "compiler.jar",
+    "cli.js",
     "index.js",
     "package.json",
     "contrib/",


### PR DESCRIPTION
This adds a binary to the distribution named `google-closure-compiler`. It's essentially a very thin wrapper around `java -jar path/to/google-closure-compiler/compiler.jar`. This means folks can access it as a cli w/o having to dig up where it's installed.

It also means that it's usable via npx. With the patch applied and published, this becomes possible:

```
$ npx google-closure-compiler …
```

Which can be used if you have it installed as a dev dep (in which case it'll be nearly instant) or even if you don't have it installed (which takes ~3s with a warm cache).

I should add, in the PR I left the bin name the same as the package, but there's no reason it couldn't be something more concise, like just `closure`.