### PR TITLE
Changed the way closure compiler is run to use nailgun

### DIFF
--- a/lib/gulp/index.js
+++ b/lib/gulp/index.js
@@ -140,87 +140,78 @@ module.exports = function(initOptions) {
     // Add the gulp-specific argument so the compiler will understand the JSON encoded input
     // for gulp, the stream mode will be 'BOTH', but when invoked from grunt, we only use
     // a stream mode of 'IN'
+  if (jsonFiles.length > 0) {
     compiler.commandArguments.push('--json_streams', this.streamMode_);
+  }
 
-    var compilerProcess = compiler.run();
-
+  compiler.run(function(compilerProcess) {
     var stdOutData = '', stdErrData = '';
 
-    compilerProcess.stdout.on('data', function (data) {
-      stdOutData += data;
-    });
-    compilerProcess.stderr.on('data', function (data) {
-      stdErrData += data;
-    });
+      compilerProcess.stdout.on('data', function (data) {
+        stdOutData += data;
+      });
+      compilerProcess.stderr.on('data', function (data) {
+        stdErrData += data;
+      });
 
-    Promise.all([
-      new Promise(function(resolve) {
-        compilerProcess.on('close', function(code) {
-          resolve(code);
-        });
-      }),
-      new Promise(function(resolve) {
-        compilerProcess.stdout.on('end', function() {
-          resolve();
-        });
-      }),
-      new Promise(function(resolve) {
-        compilerProcess.stderr.on('end', function() {
-          resolve();
-        });
-      })
-    ]).then((function(results) {
-      var code = results[0];
-
-      // standard error will contain compilation warnings, log those
-      if (stdErrData.trim().length > 0) {
-        logger(chalk.yellow(this.PLUGIN_NAME_) + ': ' + stdErrData);
-      }
-
-      // non-zero exit means a compilation error
-      if (code !== 0) {
-        this.emit('error', new PluginError(this.PLUGIN_NAME_, 'Compilation error'));
-      }
-
-      // If present, standard output will be a string of JSON encoded files.
-      // Convert these back to vinyl
-      if (stdOutData.trim().length > 0) {
-        var outputFiles;
-        try {
-          outputFiles = jsonToVinyl(stdOutData);
-        } catch (e) {
-          this.emit('error', new PluginError(this.PLUGIN_NAME_, 'Error parsing json encoded files'));
-          cb();
-          return;
-        }
-
-        for (var i = 0; i < outputFiles.length; i++) {
-          if (outputFiles[i].sourceMap) {
-            applySourceMap(outputFiles[i], outputFiles[i].sourceMap);
+      Promise.all([
+        new Promise(function(resolve) {
+          compilerProcess.stdout.on('end', function() {
+            resolve();
+          });
+        }),
+        new Promise(function(resolve) {
+          compilerProcess.stderr.on('end', function() {
+            resolve();
+          });
+        })
+      ]).then((function(results) {
+          if (stdErrData.trim().length > 0) {
+              logger(chalk.yellow(this.PLUGIN_NAME_) + ': ' + stdErrData);
           }
-          this.push(outputFiles[i]);
+
+          // If present, standard output will be a string of JSON encoded files.
+        // Convert these back to vinyl
+        if (stdOutData.trim().length > 0) {
+          var outputFiles;
+          try {
+            outputFiles = jsonToVinyl(stdOutData);
+          } catch (e) {
+            this.emit('error', new PluginError(this.PLUGIN_NAME_, 'Error parsing json encoded files'));
+            cb();
+            return;
+          }
+
+          for (var i = 0; i < outputFiles.length; i++) {
+            if (outputFiles[i].sourceMap) {
+              applySourceMap(outputFiles[i], outputFiles[i].sourceMap);
+            }
+            this.push(outputFiles[i]);
+          }
         }
+        cb();
+      }).bind(this));
+
+      // Error events occur when there was a problem spawning the compiler process
+      compilerProcess.on('error', (function (err) {
+        this.emit('error', new PluginError(this.PLUGIN_NAME_,
+            'Process spawn error. Is java in the path?\n' + err.message));
+        cb();
+      }).bind(this));
+
+      compilerProcess.stdin.on('error', (function(err) {
+        this.emit('Error', new PluginError(this.PLUGIN_NAME_,
+            'Error writing to stdin of the compiler.\n' + err.message));
+        cb();
+      }).bind(this));
+
+      if (jsonFiles.length > 0) {
+          var stdInStream = new stream.Readable({ read: function() {}});
+          stdInStream.pipe(compilerProcess.stdin);
+          stdInStream.push(JSON.stringify(jsonFiles));
+          stdInStream.push(null);
       }
-      cb();
-    }).bind(this));
-
-    // Error events occur when there was a problem spawning the compiler process
-    compilerProcess.on('error', (function (err) {
-      this.emit('error', new PluginError(this.PLUGIN_NAME_,
-          'Process spawn error. Is java in the path?\n' + err.message));
-      cb();
-    }).bind(this));
-
-    compilerProcess.stdin.on('error', (function(err) {
-      this.emit('Error', new PluginError(this.PLUGIN_NAME_,
-          'Error writing to stdin of the compiler.\n' + err.message));
-      cb();
-    }).bind(this));
-    
-    var stdInStream = new stream.Readable({ read: function() {}});
-    stdInStream.pipe(compilerProcess.stdin);
-    stdInStream.push(JSON.stringify(jsonFiles));
-    stdInStream.push(null);
+    }.bind(this));
   };
 
 

--- a/lib/node/closure-compiler.js
+++ b/lib/node/closure-compiler.js
@@ -27,6 +27,7 @@ var spawn = require('child_process').spawn;
 var compilerPath = require.resolve('../../compiler.jar');
 var path = require('path');
 var contribPath = path.dirname(compilerPath) + '/contrib';
+var nailgunServer = require('node-nailgun').createServer();
 
 /**
  * @constructor
@@ -35,10 +36,6 @@ var contribPath = path.dirname(compilerPath) + '/contrib';
  */
 function Compiler(args, extraCommandArgs) {
   this.commandArguments = (extraCommandArgs || []).slice();
-
-  if (Compiler.JAR_PATH) {
-    this.commandArguments.push('-jar', Compiler.JAR_PATH);
-  }
 
   if (Array.isArray(args)) {
     this.commandArguments = this.commandArguments.concat(args.slice());
@@ -63,11 +60,6 @@ function Compiler(args, extraCommandArgs) {
  */
 Compiler.JAR_PATH = compilerPath;
 
-/**
- * @type {string}
- */
-Compiler.prototype.javaPath = 'java';
-
 /** @type {function(...*)|null} */
 Compiler.prototype.logger = null;
 
@@ -76,40 +68,21 @@ Compiler.prototype.spawnOptions = undefined;
 
 /**
  * @param {function(number, string, string)=} callback
- * @return {child_process.ChildProcess}
  */
 Compiler.prototype.run = function(callback) {
   if (this.logger) {
     this.logger(this.getFullCommand() + '\n');
   }
 
-  var compileProcess = spawn(this.javaPath, this.commandArguments, this.spawnOptions);
+  var compileProcess = nailgunServer.spawnJar(Compiler.JAR_PATH, this.commandArguments, function(error, compileProcess) {
+    if (compileProcess !== undefined) {
+      callback(compileProcess);
+    }
 
-  var stdOutData = '', stdErrData = '';
-  if (callback) {
-    compileProcess.stdout.on('data', function (data) {
-      stdOutData += data;
-    });
-
-    compileProcess.stderr.on('data', function (data) {
-      stdErrData += data;
-    });
-
-    compileProcess.on('close', (function (code) {
-      if (code !== 0) {
-        stdErrData = this.prependFullCommand(stdErrData);
-      }
-
-      callback(code, stdOutData, stdErrData);
-    }).bind(this));
-
-    compileProcess.on('error', (function (err) {
-      callback(1, stdOutData,
-          this.prependFullCommand('Process spawn error. Is java in the path?\n' + err.message));
-    }).bind(this));
-  }
-
-  return compileProcess;
+    if (error !== undefined && error !== null) {
+      console.error(error);
+    }
+  });
 };
 
 /** @type {string} */

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,11 @@
         "through2": "2.0.3"
       }
     },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    },
     "acorn": {
       "version": "4.0.13",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
@@ -108,6 +113,11 @@
       "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
       "dev": true
     },
+    "async": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+      "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
+    },
     "atob": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/atob/-/atob-1.1.3.tgz",
@@ -125,6 +135,23 @@
       "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
       "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=",
       "dev": true
+    },
+    "binary": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+      "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
+      "requires": {
+        "buffers": "0.1.1",
+        "chainsaw": "0.1.0"
+      }
+    },
+    "block-stream": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+      "requires": {
+        "inherits": "2.0.3"
+      }
     },
     "brace-expansion": {
       "version": "1.1.8",
@@ -152,6 +179,39 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
       "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
       "dev": true
+    },
+    "bufferjs": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/bufferjs/-/bufferjs-3.0.1.tgz",
+      "integrity": "sha1-BpLoKcsQoQVQ5kc5CwNesGw46O8="
+    },
+    "buffers": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+      "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s="
+    },
+    "bufferstream": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/bufferstream/-/bufferstream-0.6.2.tgz",
+      "integrity": "sha1-pfJ+ENPHYAhNFLNRJmFQBzGeNzE=",
+      "requires": {
+        "bufferjs": "3.0.1",
+        "buffertools": "2.1.6"
+      }
+    },
+    "buffertools": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/buffertools/-/buffertools-2.1.6.tgz",
+      "integrity": "sha1-MMGbCFY2uI32kq7v7qD/FWeA6RY=",
+      "optional": true
+    },
+    "chainsaw": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+      "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
+      "requires": {
+        "traverse": "0.3.9"
+      }
     },
     "chalk": {
       "version": "1.1.3",
@@ -189,6 +249,11 @@
         "process-nextick-args": "1.0.7",
         "through2": "2.0.3"
       }
+    },
+    "colors": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+      "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w="
     },
     "commander": {
       "version": "2.9.0",
@@ -323,6 +388,43 @@
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
           "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A=",
           "dev": true
+        }
+      }
+    },
+    "decompress-zip": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.1.0.tgz",
+      "integrity": "sha1-vOYMEWZPLWYPykvPY0r23l1sFMc=",
+      "requires": {
+        "binary": "0.3.0",
+        "graceful-fs": "3.0.11",
+        "mkpath": "0.1.0",
+        "nopt": "3.0.6",
+        "q": "1.5.1",
+        "readable-stream": "1.1.14",
+        "touch": "0.0.3"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
     },
@@ -639,6 +741,24 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "fstream": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "inherits": "2.0.3",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.2.8"
+      },
+      "dependencies": {
+        "graceful-fs": {
+          "version": "4.1.11",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+        }
+      }
+    },
     "gaze": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
@@ -840,7 +960,6 @@
       "version": "3.0.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
       "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
-      "dev": true,
       "requires": {
         "natives": "1.1.0"
       }
@@ -1234,11 +1353,27 @@
         "isarray": "1.0.0"
       }
     },
+    "jarfile": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/jarfile/-/jarfile-1.0.4.tgz",
+      "integrity": "sha1-eTFnwd5D6dFTq5xJoVXP2IY7B4o=",
+      "requires": {
+        "ls-archive": "1.2.3"
+      }
+    },
     "json3": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
       "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
       "dev": true
+    },
+    "jvmpin": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/jvmpin/-/jvmpin-1.0.10.tgz",
+      "integrity": "sha1-Pun+iPS1hSM1YTVgGBoe0irgGSY=",
+      "requires": {
+        "bufferstream": "0.6.2"
+      }
     },
     "kind-of": {
       "version": "3.2.2",
@@ -1451,6 +1586,20 @@
         "es5-ext": "0.10.26"
       }
     },
+    "ls-archive": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/ls-archive/-/ls-archive-1.2.3.tgz",
+      "integrity": "sha1-CUMf6ymhSHGpTqQ2PC3LAHxHalY=",
+      "requires": {
+        "async": "0.2.10",
+        "colors": "0.6.2",
+        "decompress-zip": "0.1.0",
+        "optimist": "0.5.2",
+        "rimraf": "2.2.8",
+        "tar": "2.2.1",
+        "tmp": "0.0.31"
+      }
+    },
     "map-cache": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
@@ -1513,7 +1662,6 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       },
@@ -1521,10 +1669,14 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
+    },
+    "mkpath": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz",
+      "integrity": "sha1-dVSm+Nhxg0zJe1RisSLEwSTW3pE="
     },
     "mocha": {
       "version": "3.5.0",
@@ -1597,8 +1749,7 @@
     "natives": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz",
-      "integrity": "sha1-6f+EFBimsux6SV6TmYT3jxY+bjE=",
-      "dev": true
+      "integrity": "sha1-6f+EFBimsux6SV6TmYT3jxY+bjE="
     },
     "ncp": {
       "version": "2.0.0",
@@ -1611,6 +1762,23 @@
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
+    },
+    "node-nailgun": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/node-nailgun/-/node-nailgun-1.0.2.tgz",
+      "integrity": "sha1-NHQ51fu3/5XEO6y4F24bOrgY9pM=",
+      "requires": {
+        "jarfile": "1.0.4",
+        "jvmpin": "1.0.10"
+      }
+    },
+    "nopt": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "requires": {
+        "abbrev": "1.1.1"
+      }
     },
     "normalize-path": {
       "version": "2.1.1",
@@ -1693,6 +1861,14 @@
         "wrappy": "1.0.2"
       }
     },
+    "optimist": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.5.2.tgz",
+      "integrity": "sha1-hcjBRUszFeSniUfoV7HfAzRQv7w=",
+      "requires": {
+        "wordwrap": "0.0.3"
+      }
+    },
     "orchestrator": {
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.8.tgz",
@@ -1715,6 +1891,11 @@
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "p-finally": {
       "version": "1.0.0",
@@ -1806,6 +1987,11 @@
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
+    },
+    "q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
     },
     "randomatic": {
       "version": "1.1.7",
@@ -1927,6 +2113,11 @@
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
+    },
+    "rimraf": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+      "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
     },
     "safe-buffer": {
       "version": "5.1.1",
@@ -2149,6 +2340,16 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
     },
+    "tar": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+      "requires": {
+        "block-stream": "0.0.9",
+        "fstream": "1.0.11",
+        "inherits": "2.0.3"
+      }
+    },
     "through2": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
@@ -2182,6 +2383,37 @@
         "es5-ext": "0.10.26",
         "next-tick": "1.0.0"
       }
+    },
+    "tmp": {
+      "version": "0.0.31",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
+      "integrity": "sha1-jzirlDjhcxXl29izZX6L+yd65Kc=",
+      "requires": {
+        "os-tmpdir": "1.0.2"
+      }
+    },
+    "touch": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-0.0.3.tgz",
+      "integrity": "sha1-Ua7z1ElXHU8oel2Hyci0kYGg2x0=",
+      "requires": {
+        "nopt": "1.0.10"
+      },
+      "dependencies": {
+        "nopt": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+          "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
+          "requires": {
+            "abbrev": "1.1.1"
+          }
+        }
+      }
+    },
+    "traverse": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+      "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk="
     },
     "unc-path-regex": {
       "version": "0.1.2",
@@ -2324,6 +2556,11 @@
       "requires": {
         "isexe": "2.0.0"
       }
+    },
+    "wordwrap": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
     },
     "wrappy": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "homepage": "https://developers.google.com/closure/compiler/",
   "dependencies": {
     "chalk": "^1.0.0",
+    "node-nailgun": "^1.0.2",
     "vinyl": "^2.0.1",
     "vinyl-sourcemaps-apply": "^0.2.0"
   },


### PR DESCRIPTION
I was trying to find an alternative for plovr while development, because plovr is a little bit far behind and upgrading google closure every time is becoming troublesome there.

So I considered using gulp. I set up a gulp webserver using gulp connect and on fallback, it triggers the google closure compile, then it waits until the file is generated and it will then serve it to the client. The problem that I am facing is that the compile time is much bigger than plovr ~40s vs ~20s. So I managed to solve that by using nailgun to run the jar, and this way I can avoid the overhead of the jvm run time. and I actually reached the same compile time as plovr.

The is only one problem with this pull request that using running closure compiler using src won't work anymore, it gives that error in from the compile process error
```
{ Error: Nailgun failed to start up.
    at NailgunServer._receiveServerClose (/home/hatem/coscale/interfaces/app/node_modules/node-nailgun/src/NailgunServer.js:107:19)
    at emitTwo (events.js:106:13)
    at ChildProcess.emit (events.js:191:7)
    at maybeClose (internal/child_process.js:920:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:230:5)
  nailgunStdout: 'com.martiansoftware.nailgun.builtins.NGAlias: 0/0\ncom.martiansoftware.nailgun.builtins.NGClasspath: 0/0\ncom.martiansoftware.nailgun.builtins.NGServerStats: 0/0\ncom.martiansoftware.nailgun.builtins.NGStop: 0/0\ncom.martiansoftware.nailgun.builtins.NGVersion: 0/0\nNGServer shut down.\n' }
```
I could not find the solution for this problem, so any help here would be appreciated.

Here is a link for my initial problem:
https://stackoverflow.com/questions/46957958/decreasing-google-closure-run-time-using-gulp
