### PR TITLE
[WIP] Make changes to support the JS version in the same package

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ grunt.initConfig({
 
 ```js
 
-var compilerPackage = require('google-closure-compiler');
+const compilerPackage = require('google-closure-compiler');
 compilerPackage.grunt(grunt);
 
 // Project configuration.
@@ -187,7 +187,7 @@ Options are a direct match to the compiler flags without the leading "--".
 ### Basic Configuration Example:
 
 ```js
-var closureCompiler = require('google-closure-compiler').gulp();
+const closureCompiler = require('google-closure-compiler').gulp();
 
 gulp.task('js-compile', function () {
   return gulp.src('./src/js/**/*.js', {base: './'})
@@ -210,8 +210,8 @@ compiler. With large source sets this may require a large amount of memory.
 Closure-compiler can natively expand file globs which will greatly alleviate this issue.
 
 ```js
-var compilerPackage = require('google-closure-compiler');
-var closureCompiler = compilerPackage.gulp();
+const compilerPackage = require('google-closure-compiler');
+const closureCompiler = compilerPackage.gulp();
 
 gulp.task('js-compile', function () {
   return closureCompiler({
@@ -237,7 +237,7 @@ this behavior.
 ### Advanced Usage with Arguments Array:
 
 ```js
-var closureCompiler = require('google-closure-compiler').gulp();
+const closureCompiler = require('google-closure-compiler').gulp();
 
 gulp.task('js-compile', function () {
   return closureCompiler([
@@ -256,8 +256,8 @@ gulp.task('js-compile', function () {
 The gulp plugin supports gulp sourcemaps.
 
 ```js
-var closureCompiler = require('google-closure-compiler').gulp();
-var sourcemaps = require('gulp-sourcemaps');
+const closureCompiler = require('google-closure-compiler').gulp();
+const sourcemaps = require('gulp-sourcemaps');
 
 gulp.task('js-compile', function () {
   return gulp.src('./src/js/**/*.js', {base: './'})
@@ -285,8 +285,8 @@ npm install closure-gun
 
 ### Gulp
 ```js
-var compilerPackage = require('google-closure-compiler');
-var closureCompiler = compilerPackage.gulp();
+const compilerPackage = require('google-closure-compiler');
+const closureCompiler = compilerPackage.gulp();
 
 compilerPackage.compiler.JAR_PATH = undefined;
 compilerPackage.compiler.prototype.javaPath = './node_modules/.bin/closure-gun'
@@ -296,8 +296,8 @@ Note that when using gulp, Only without gulp.src works with nailgun.
 
 ### Grunt
 ```js
-var compilerPackage = require('google-closure-compiler');
-var closureCompiler = compilerPackage.grunt();
+const compilerPackage = require('google-closure-compiler');
+const closureCompiler = compilerPackage.grunt();
 
 compilerPackage.compiler.JAR_PATH = undefined;
 compilerPackage.compiler.prototype.javaPath = './node_modules/.bin/closure-gun'
@@ -314,7 +314,7 @@ require('google-closure-compiler').grunt(grunt, ['-Xms2048m']);
 
 ### Gulp
 ```js
-var closureCompiler = require('google-closure-compiler').gulp({
+const closureCompiler = require('google-closure-compiler').gulp({
   extraArguments: ['-Xms2048m']
 });
 ```
@@ -324,17 +324,17 @@ A low-level node class is included to facilitate spawning the compiler jar as a 
 In addition, it exposes a static property with the path to the compiler jar file.
 
 ```js
-var ClosureCompiler = require('google-closure-compiler').compiler;
+const ClosureCompiler = require('google-closure-compiler').compiler;
 
 console.log(ClosureCompiler.COMPILER_PATH); // absolute path the compiler jar
 console.log(ClosureCompiler.CONTRIB_PATH); // absolute path the contrib folder which contains
 
-var closureCompiler = new ClosureCompiler({
+const closureCompiler = new ClosureCompiler({
   js: 'file-one.js',
   compilation_level: 'ADVANCED'
 });
 
-var compilerProcess = closureCompiler.run(function(exitCode, stdOut, stdErr) {
+const compilerProcess = closureCompiler.run(function(exitCode, stdOut, stdErr) {
   //compilation complete
 });
 ```

--- a/index.js
+++ b/index.js
@@ -22,12 +22,14 @@
 
 'use strict';
 
-var grunt_plugin = require('./lib/grunt');
-var gulp_plugin = require('./lib/gulp');
-var Compiler = require('./lib/node/closure-compiler');
+const grunt_plugin = require('./lib/grunt');
+const gulp_plugin = require('./lib/gulp');
+const Compiler = require('./lib/node/closure-compiler');
+const CompilerJS = require('./lib/node/closure-compiler-js');
 
 module.exports = {
   grunt: grunt_plugin,
   compiler: Compiler,
+  jsCompiler: CompilerJS,
   gulp: gulp_plugin
 };

--- a/lib/grunt/index.js
+++ b/lib/grunt/index.js
@@ -29,21 +29,16 @@
 module.exports = (grunt, extraArguments) => {
   const chalk = require('chalk');
   const VinylStream = require('./vinyl-stream');
-  const gulpCompiler = require('../gulp')({extraArguments: extraArguments});
   const Transform = require('stream').Transform;
-  const gulpCompilerOptions = {
-    streamMode: 'IN',
-    logger: grunt.log,
-    pluginName: 'grunt-google-closure-compiler',
-    requireStreamInput: false
-  };
+  const gulpCompilerOptions = {};
+  const gulp = require('gulp');
 
   /**
    * @param {Array<string>}|null} files
    * @param {Object<string,string|boolean|Array<string>>|Array<string>} options
    * @return {Promise}
    */
-  function compilationPromise(files, options) {
+  function compilationPromise(files, options, pluginOpts) {
     let hadError = false;
     function logFile(cb) {
       // If an error was encoutered, it will have already been logged
@@ -65,17 +60,50 @@ module.exports = (grunt, extraArguments) => {
 
     return new Promise(function(resolve, reject) {
       let stream;
+      const args = Object.assign({}, {jsMode: extraArguments === 'javascript'});
+      let gulpOpts;
+      if (args.jsMode) {
+        gulpOpts = Object.assign({}, gulpCompilerOptions, {
+          jsMode: true,
+          logger: grunt.log,
+          pluginName: 'grunt-google-closure-compiler'
+        });
+      } else {
+        gulpOpts = Object.assign({}, gulpCompilerOptions, {
+          streamMode: 'IN',
+          logger: grunt.log,
+          pluginName: 'grunt-google-closure-compiler',
+          requireStreamInput: false
+        });
+      };
+      if (extraArguments && extraArguments !== 'javascript') {
+        args.extraArguments = extraArguments;
+      }
+      const gulpCompiler = require('../gulp')(args);
+      const compilerOpts = Object.assign({}, gulpOpts, pluginOpts);
       if (files) {
         // Source files were provided by grunt. Read these
         // in to a stream of vinyl files and pipe them through
         // the compiler task
         stream = new VinylStream(files, {base: process.cwd()})
-            .pipe(gulpCompiler(options, gulpCompilerOptions));
+            .pipe(gulpCompiler(options, compilerOpts));
+        if (args.jsMode) {
+          stream = stream.on('error', err => {
+            hadError = true;
+            reject(err);
+          }).pipe(gulp.dest(""));
+        }
       } else {
         // No source files were provided. Assume the options specify
         // --js flags and invoke the compiler without any grunt inputs.
         // Manually end the stream to force compilation to begin.
-        stream = gulpCompiler(options, gulpCompilerOptions);
+        stream = gulpCompiler(options, compilerOpts);
+        if (args.jsMode) {
+          stream = stream.on('error', err => {
+            hadError = true;
+            reject(err);
+          }).pipe(gulp.dest(""));
+        }
         stream.end();
       }
 
@@ -105,9 +133,10 @@ module.exports = (grunt, extraArguments) => {
       const args = opts.args;
 
       delete opts.args;
+      delete opts.jsMode;
 
       return {
-        args: args,
+        args,
         compilerOpts: opts
       }
     }
@@ -133,7 +162,7 @@ module.exports = (grunt, extraArguments) => {
         options.compilerOpts.js_output_file = f.dest;
       }
 
-      compileTasks.push(compilationPromise(src, options.args || options.compilerOpts)
+      compileTasks.push(compilationPromise(src, options.args || options.compilerOpts, {jsMode: options.jsMode})
           .then(function () {}, function(err) {
             throw err;
           }));
@@ -143,7 +172,7 @@ module.exports = (grunt, extraArguments) => {
     // --js flags are present and we want to run the compiler anyway.
     if (taskObject.files.length === 0) {
       const options = getCompilerOptions();
-      compileTasks.push(compilationPromise(null, options.args || options.compilerOpts));
+      compileTasks.push(compilationPromise(null, options.args || options.compilerOpts, {jsMode: options.jsMode}));
     }
 
     // Multiple invocations of the compiler can occur for a single task target. Wait until

--- a/lib/gulp/index.js
+++ b/lib/gulp/index.js
@@ -29,14 +29,8 @@
 'use strict';
 
 class CustomError extends Error {
-  constructor(plugin, msg) {
-    super(message);
-    this.name = this.constructor.name;
-    if (typeof Error.captureStackTrace === 'function') {
-      Error.captureStackTrace(this, this.constructor);
-    } else {
-      this.stack = (new Error(message)).stack;
-    }
+  constructor(plugin, message) {
+    super(`${plugin}: ${message}`);
   }
 }
 
@@ -47,12 +41,12 @@ class CustomError extends Error {
 module.exports = function(initOptions) {
   const filesToJson = require('./concat-to-json');
   const jsonToVinyl = require('./json-to-vinyl');
-  const Compiler = require('../node/closure-compiler');
   const stream = require('stream');
   /** @const */
   const PLUGIN_NAME = 'gulp-google-closure-compiler';
 
   const extraCommandArguments = initOptions ? initOptions.extraArguments : undefined;
+  const jsMode = Boolean(initOptions && initOptions.jsMode);
   const applySourceMap = require('vinyl-sourcemaps-apply');
   const chalk = require('chalk');
   const File = require('vinyl');
@@ -70,6 +64,8 @@ module.exports = function(initOptions) {
   } catch(e) {
     gulpLog = console;
   }
+
+  const Compiler = jsMode ? require('../node/closure-compiler-js') : require('../node/closure-compiler');
 
   class CompilationStream extends stream.Transform {
     constructor(compilationOptions, pluginOptions) {
@@ -110,13 +106,16 @@ module.exports = function(initOptions) {
         return;
       }
 
+      if (file.sourceMap && jsMode) {
+        this.compilationOptions_.createSourceMap = true;
+      }
+
       this.fileList_.push(file);
       cb();
     }
 
     _flush(cb) {
       let jsonFiles;
-      const logger = this.logger_.warn ? this.logger_.warn : this.logger_;
       if (this.fileList_.length > 0) {
         // Input files are present. Convert them to a JSON encoded string
         jsonFiles = filesToJson(this.fileList_);
@@ -132,82 +131,107 @@ module.exports = function(initOptions) {
         // list if no files were piped into this plugin.
         jsonFiles = [];
       }
-
       const compiler = new Compiler(this.compilationOptions_, extraCommandArguments);
-
-      // Add the gulp-specific argument so the compiler will understand the JSON encoded input
-      // for gulp, the stream mode will be 'BOTH', but when invoked from grunt, we only use
-      // a stream mode of 'IN'
-      compiler.commandArguments.push('--json_streams', this.streamMode_);
-
-      const compilerProcess = compiler.run();
-
-      let stdOutData = '';
-      let stdErrData = '';
-
-      compilerProcess.stdout.on('data', data => {
-        stdOutData += data;
-      });
-      compilerProcess.stderr.on('data', data => {
-        stdErrData += data;
-      });
-
-      Promise.all([
-        new Promise(resolve => compilerProcess.on('close', resolve)),
-        new Promise(resolve => compilerProcess.stdout.on('end', resolve)),
-        new Promise(resolve => compilerProcess.stderr.on('end', resolve))
-      ]).then(results => {
-        const code = results[0];
-
-        // standard error will contain compilation warnings, log those
-        if (stdErrData.trim().length > 0) {
-          logger(chalk.yellow(this.PLUGIN_NAME_) + ': ' + stdErrData);
+      if (jsMode) {
+        let compilerProcess;
+        try {
+          compilerProcess = compiler.run(jsonFiles);
+        } catch (e) {
+          this._compilationComplete(1, [], e.message.replace(/^java.lang.RuntimeException: /, ''));
+          cb();
+          return;
         }
+        const errors = [].slice.call(compilerProcess.warnings).concat([].slice.call(compilerProcess.errors));
+        this._compilationComplete(
+            compilerProcess.errors.length === 0 ? 0 : 1,
+            compilerProcess.compiledFiles,
+            errors.join('\n\n'));
+        cb();
+      } else {
+        let stdOutData = '';
+        let stdErrData = '';
 
-        // non-zero exit means a compilation error
-        if (code !== 0) {
-          this.emit('error', new PluginError(this.PLUGIN_NAME_, 'Compilation error'));
-        }
+        // Add the gulp-specific argument so the compiler will understand the JSON encoded input
+        // for gulp, the stream mode will be 'BOTH', but when invoked from grunt, we only use
+        // a stream mode of 'IN'
+        compiler.commandArguments.push('--json_streams', this.streamMode_);
+        const compilerProcess = compiler.run();
 
-        // If present, standard output will be a string of JSON encoded files.
-        // Convert these back to vinyl
-        if (stdOutData.trim().length > 0) {
-          let outputFiles;
-          try {
-            outputFiles = jsonToVinyl(stdOutData);
-          } catch (e) {
-            this.emit('error', new PluginError(this.PLUGIN_NAME_, 'Error parsing json encoded files'));
-            cb();
-            return;
-          }
+        compilerProcess.stdout.on('data', data => {
+          stdOutData += data;
+        });
+        compilerProcess.stderr.on('data', data => {
+          stdErrData += data;
+        });
+        let launchDidError = false;
+        // Error events occur when there was a problem spawning the compiler process
+        compilerProcess.on('error', err => {
+          launchDidError = true;
+          this.emit('error', new PluginError(this.PLUGIN_NAME_,
+              'Process spawn error. Is java in the path?\n' + err.message));
+          cb();
+        });
 
-          for (let i = 0; i < outputFiles.length; i++) {
-            if (outputFiles[i].sourceMap) {
-              applySourceMap(outputFiles[i], outputFiles[i].sourceMap);
+        compilerProcess.stdin.on('error', err => {
+          this.emit('Error', new PluginError(this.PLUGIN_NAME_,
+              'Error writing to stdin of the compiler.\n' + err.message));
+          cb();
+        });
+
+        Promise.all([
+          new Promise(resolve => compilerProcess.on('close', resolve)),
+          new Promise(resolve => compilerProcess.stdout.on('end', resolve)),
+          new Promise(resolve => compilerProcess.stderr.on('end', resolve))
+        ]).then(results => {
+          const code = results[0];
+
+          // If present, standard output will be a string of JSON encoded files.
+          // Convert these back to vinyl
+          let outputFiles = [];
+          if (stdOutData.trim().length > 0) {
+            // stdOutData = stdOutData.substr(stdOutData.indexOf('{'));
+            try {
+              outputFiles = JSON.parse(stdOutData);
+            } catch (e) {
+              this.emit('error', new PluginError(this.PLUGIN_NAME_, 'Error parsing json encoded files'));
+              cb();
+              return;
             }
-            this.push(outputFiles[i]);
           }
+
+          this._compilationComplete(code, outputFiles, stdErrData);
+          cb();
+        });
+
+        const stdInStream = new stream.Readable({ read: function() {}});
+        stdInStream.pipe(compilerProcess.stdin);
+        stdInStream.push(JSON.stringify(jsonFiles));
+        stdInStream.push(null);
+      }
+    }
+
+    _compilationComplete(exitCode, compiledJs, errors) {
+      // non-zero exit means a compilation error
+      if (exitCode !== 0) {
+        this.emit('error', new PluginError(this.PLUGIN_NAME_, 'Compilation error'));
+      }
+
+      // standard error will contain compilation warnings, log those
+      if (errors && errors.trim().length > 0) {
+        const logger = this.logger_.warn ? this.logger_.warn : this.logger_;
+        logger(`${chalk.yellow(this.PLUGIN_NAME_)}: ${errors}`);
+      }
+
+      // If present, standard output will be a string of JSON encoded files.
+      // Convert these back to vinyl
+      let outputFiles = jsonToVinyl(compiledJs);
+
+      for (let i = 0; i < outputFiles.length; i++) {
+        if (outputFiles[i].sourceMap) {
+          applySourceMap(outputFiles[i], outputFiles[i].sourceMap);
         }
-        cb();
-      });
-
-      // Error events occur when there was a problem spawning the compiler process
-      compilerProcess.on('error', err => {
-        this.emit('error', new PluginError(this.PLUGIN_NAME_,
-            'Process spawn error. Is java in the path?\n' + err.message));
-        cb();
-      });
-
-      compilerProcess.stdin.on('error', err => {
-        this.emit('Error', new PluginError(this.PLUGIN_NAME_,
-            'Error writing to stdin of the compiler.\n' + err.message));
-        cb();
-      });
-
-      const stdInStream = new stream.Readable({ read: function() {}});
-      stdInStream.pipe(compilerProcess.stdin);
-      stdInStream.push(JSON.stringify(jsonFiles));
-      stdInStream.push(null);
+        this.push(outputFiles[i]);
+      }
     }
   }
 

--- a/lib/gulp/json-to-vinyl.js
+++ b/lib/gulp/json-to-vinyl.js
@@ -29,19 +29,15 @@ const File = require('vinyl');
  * @param {string} input string of json encoded files
  * @return {Array<Object>}
  */
-module.exports = input => {
-  let fileList;
-  const outputFiles = [];
-
-  fileList = JSON.parse(input);
-
+module.exports = fileList => {
+  let outputFiles = [];
   for (let i = 0; i < fileList.length; i++) {
     const file = new File({
       path: fileList[i].path,
       contents: Buffer.from(fileList[i].src)
     });
-    if (fileList[i].source_map) {
-      file.sourceMap = JSON.parse(fileList[i].source_map);
+    if (fileList[i].source_map || fileList[i].sourceMap) {
+      file.sourceMap = JSON.parse(fileList[i].source_map || fileList[i].sourceMap);
     }
     outputFiles.push(file);
   }

--- a/lib/node/closure-compiler-js.js
+++ b/lib/node/closure-compiler-js.js
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2018 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Low level class for calling the closure-compiler-js lib
+ *
+ * @author Chad Killingsworth (chadkillingsworth@gmail.com)
+ */
+
+'use strict';
+
+const path = require('path');
+const contribPath = path.dirname(path.resolve(__dirname, '../../')) + '/contrib';
+const jscomp = require('../../jscomp.js');
+
+class CompilerJS {
+  /** @param {Object<string,string>|Array<string>} flags */
+  constructor(flags) {
+    this.flags = {};
+    if (Array.isArray(flags)) {
+      flags.forEach(flag => {
+        const flagPargs = flag.split('=');
+        const normalizedFlag = this.formatArgument(flagPargs[0], flagPargs[1]);
+        this.flags[normalizedFlag.key] = normalizedFlag.val;
+      });
+    } else {
+      for (let key in flags) {
+        const normalizedFlag = this.formatArgument(key, flags[key]);
+        this.flags[normalizedFlag.key] = normalizedFlag.val;
+      }
+    }
+  }
+
+  /**
+   * @param {!Array<!{src: string, path: string, sourceMap: string}>} fileList
+   * @param {function(number, string, string)=} callback
+   * @return {child_process.ChildProcess}
+   */
+  run(fileList, callback) {
+    const out = jscomp(this.flags, fileList);
+    if (callback) {
+      const warnings = Array.prototype.slice.call(out.warnings);
+      const errors = Array.prototype.slice.call(out.errors);
+      callback(errors.length === 0 ? 0 : 1, out.compiledFiles, out.warnings.concat(out.errors).join('\n\n'));
+    }
+    return out;
+  }
+
+  /**
+   * @param {string} key
+   * @param {(string|boolean)=} val
+   * @return {{key: string, val: (string|undefined)}}
+   */
+  formatArgument(key, val) {
+    let normalizedKey = key.replace(/_(\w)/g, match => match[1].toUpperCase());
+    normalizedKey = normalizedKey.replace(/^--/, '');
+
+    return {
+      key: normalizedKey,
+      val: val === undefined || val === null ? true : val
+    };
+  }
+}
+
+/** @type {string} */
+CompilerJS.CONTRIB_PATH = contribPath;
+
+module.exports = CompilerJS;

--- a/lib/node/closure-compiler.js
+++ b/lib/node/closure-compiler.js
@@ -118,11 +118,14 @@ class Compiler {
    * @return {string}
    */
   formatArgument(key, val) {
+    let normalizedKey = key.replace(/[A-Z]/g, match => `_${match.toLowerCase()}`);
+    normalizedKey = normalizedKey.replace(/^--/, '');
+
     if (val === undefined || val === null) {
-      return '--' + key;
+      return `--${normalizedKey}`;
     }
 
-    return '--' + key + '=' + val;
+    return `--${normalizedKey}=${val}`;
   }
 }
 

--- a/test/gulp.js
+++ b/test/gulp.js
@@ -27,120 +27,121 @@ const gulp = require('gulp');
 const sourcemaps = require('gulp-sourcemaps');
 const File = require('vinyl');
 const compilerPackage = require('../');
-const closureCompiler = compilerPackage.gulp();
 require('mocha');
 
 process.on('unhandledRejection', e => { throw e; });
 
 describe('gulp-google-closure-compiler', function() {
-  this.timeout(30000);
-  this.slow(10000);
+  ['java', 'javascript'].forEach(mode => {
+    describe(`${mode} version`, function() {
+      const closureCompiler = compilerPackage.gulp({jsMode: mode === 'javascript'});
+      this.timeout(30000);
+      this.slow(10000);
 
-  describe('in buffer mode', () => {
-    const fakeFile1 = new File({
-      path: '/foo.js',
-      contents: new Buffer('console.log("foo");')
-    });
-    const fakeFile2 = new File({
-      path: '/bar.js',
-      contents: new Buffer('console.log("bar");')
-    });
-
-    const fixturesCompiled = 'function log(a){console.log(a)}log("one.js");' +
-        'var WindowInfo=function(){this.props=[]};WindowInfo.prototype.propList=function(){' +
-        'for(var a in window)this.props.push(a)};WindowInfo.prototype.list=function(){' +
-        'log(this.props.join(", "))};(new WindowInfo).list();\n';
-
-
-    it('should emit an error for invalid options', done => {
-      const stream = closureCompiler({
-        compilation_level: 'FOO'
+      const fakeFile1 = new File({
+        path: '/foo.js',
+        contents: new Buffer('console.log("foo");')
+      });
+      const fakeFile2 = new File({
+        path: '/bar.js',
+        contents: new Buffer('console.log("bar");')
       });
 
-      stream.on('error', err => {
-        err.message.should.startWith('Compilation error');
-        done();
-      });
-      stream.write(fakeFile1);
-      stream.end();
-    });
+      const fixturesCompiled = 'function log(a){console.log(a)}log("one.js");' +
+          'var WindowInfo=function(){this.props=[]};WindowInfo.prototype.propList=function(){' +
+          'for(var a in window)this.props.push(a)};WindowInfo.prototype.list=function(){' +
+          'log(this.props.join(", "))};(new WindowInfo).list();\n';
 
-    it('should compile a single file', done => {
-      const stream = closureCompiler({
-        compilation_level: 'SIMPLE',
-        warning_level: 'VERBOSE'
-      });
+      it('should emit an error for invalid options', done => {
+        const stream = closureCompiler({
+          compilation_level: 'FOO'
+        });
 
-      stream.pipe(assert.length(1))
-          .pipe(assert.first(f => {
-                f.contents.toString().trim().should.eql(fakeFile1.contents.toString());
-           }))
-           .pipe(assert.end(done));
-
-      stream.write(fakeFile1);
-      stream.end();
-    });
-
-    it('should name the output file when no js_output_file option is provided', done => {
-      const stream = closureCompiler({
-        compilation_level: 'SIMPLE',
-        warning_level: 'VERBOSE'
-      });
-      stream.pipe(assert.length(1))
-          .pipe(assert.first(f => {
-            f.path.should.eql('compiled.js');
-          }))
-          .pipe(assert.end(done));
-
-      stream.write(fakeFile1);
-      stream.end();
-    });
-
-    it('should name the output file from the js_output_file option', done => {
-      const stream = closureCompiler({
-        compilation_level: 'SIMPLE',
-        warning_level: 'VERBOSE',
-        js_output_file: 'out.js'
-      });
-      stream.pipe(assert.length(1))
-          .pipe(assert.first(f => {
-            f.path.should.eql('out.js');
-          }))
-          .pipe(assert.end(done));
-
-      stream.write(fakeFile1);
-      stream.end();
-    });
-
-    it('should compile multiple input files into a single output', done => {
-      const stream = closureCompiler({
-        compilation_level: 'SIMPLE',
-        warning_level: 'VERBOSE'
+        stream.on('error', err => {
+          err.message.should.startWith('Compilation error');
+          done();
+        });
+        stream.write(fakeFile1);
+        stream.end();
       });
 
-      stream.pipe(assert.length(1))
-          .pipe(assert.first(f => {
-            f.contents.toString().trim().should.eql(fakeFile1.contents.toString() +
-                fakeFile2.contents.toString());
-          }))
-          .pipe(assert.end(done));
+      it('should compile a single file', done => {
+        const stream = closureCompiler({
+          compilation_level: 'SIMPLE',
+          warning_level: 'VERBOSE'
+        });
 
-      stream.write(fakeFile1);
-      stream.write(fakeFile2);
-      stream.end();
-    });
+        stream.pipe(assert.length(1))
+        .pipe(assert.first(f => {
+          f.contents.toString().trim().should.eql(fakeFile1.contents.toString());
+        }))
+        .pipe(assert.end(done));
 
-    it('should compile multiple inputs into multiple outputs with module options', done => {
-      const stream = closureCompiler({
-        compilation_level: 'SIMPLE',
-        warning_level: 'VERBOSE',
-        module: [
-          'one:1',
-          'two:1'
-        ]
+        stream.write(fakeFile1);
+        stream.end();
       });
 
-      stream.pipe(assert.length(2))
+      it('should name the output file when no js_output_file option is provided', done => {
+        const stream = closureCompiler({
+          compilation_level: 'SIMPLE',
+          warning_level: 'VERBOSE'
+        });
+        stream.pipe(assert.length(1))
+        .pipe(assert.first(f => {
+          f.path.should.eql('compiled.js');
+        }))
+        .pipe(assert.end(done));
+
+        stream.write(fakeFile1);
+        stream.end();
+      });
+
+      it('should name the output file from the js_output_file option', done => {
+        const stream = closureCompiler({
+          compilation_level: 'SIMPLE',
+          warning_level: 'VERBOSE',
+          js_output_file: 'out.js'
+        });
+        stream.pipe(assert.length(1))
+        .pipe(assert.first(f => {
+          f.path.should.eql('out.js');
+        }))
+        .pipe(assert.end(done));
+
+        stream.write(fakeFile1);
+        stream.end();
+      });
+
+      it('should compile multiple input files into a single output', done => {
+        const stream = closureCompiler({
+          compilation_level: 'SIMPLE',
+          warning_level: 'VERBOSE'
+        });
+
+        stream.pipe(assert.length(1))
+        .pipe(assert.first(f => {
+          f.contents.toString().trim().should.eql(fakeFile1.contents.toString() +
+              fakeFile2.contents.toString());
+        }))
+        .pipe(assert.end(done));
+
+        stream.write(fakeFile1);
+        stream.write(fakeFile2);
+        stream.end();
+      });
+
+      if (mode !== 'javascript') {
+        it('should compile multiple inputs into multiple outputs with module options', done => {
+          const stream = closureCompiler({
+            compilation_level: 'SIMPLE',
+            warning_level: 'VERBOSE',
+            module: [
+              'one:1',
+              'two:1'
+            ]
+          });
+
+          stream.pipe(assert.length(2))
           .pipe(assert.first(f => {
             f.contents.toString().trim().should.eql(fakeFile1.contents.toString());
             f.path.should.eql('one.js');
@@ -151,28 +152,30 @@ describe('gulp-google-closure-compiler', function() {
           }))
           .pipe(assert.end(done));
 
-      stream.write(fakeFile1);
-      stream.write(fakeFile2);
-      stream.end();
-    });
+          stream.write(fakeFile1);
+          stream.write(fakeFile2);
+          stream.end();
+        });
+      }
 
-    it('should generate a sourcemap for a single output file', done => {
-      gulp.src('test/fixtures/**/*.js', {base: './'})
-          .pipe(sourcemaps.init())
-          .pipe(closureCompiler({
-            compilation_level: 'SIMPLE',
-            warning_level: 'VERBOSE'
-          }))
-          .pipe(assert.length(1))
-          .pipe(assert.first(f => {
-            f.sourceMap.sources.should.have.length(2);
-            f.sourceMap.file.should.eql('compiled.js');
-          }))
-          .pipe(assert.end(done));
-    });
+      it('should generate a sourcemap for a single output file', done => {
+        gulp.src('test/fixtures/**/*.js', {base: './'})
+        .pipe(sourcemaps.init())
+        .pipe(closureCompiler({
+          compilation_level: 'SIMPLE',
+          warning_level: 'VERBOSE'
+        }))
+        .pipe(assert.length(1))
+        .pipe(assert.first(f => {
+          f.sourceMap.sources.should.have.length(2);
+          f.sourceMap.file.should.eql('compiled.js');
+        }))
+        .pipe(assert.end(done));
+      });
 
-    it('should generate a sourcemap for each output file with modules', done => {
-      gulp.src(__dirname + '/fixtures/**/*.js')
+      if (mode !== 'javascript') {
+        it('should generate a sourcemap for each output file with modules', done => {
+          gulp.src(__dirname + '/fixtures/**/*.js')
           .pipe(sourcemaps.init())
           .pipe(closureCompiler({
             compilation_level: 'SIMPLE',
@@ -192,10 +195,10 @@ describe('gulp-google-closure-compiler', function() {
             f.sourceMap.file.should.eql('./two.js');
           }))
           .pipe(assert.end(done));
-    });
+        });
 
-    it('should support passing input globs directly to the compiler', done => {
-      const stream = closureCompiler({
+        it('should support passing input globs directly to the compiler', done => {
+          const stream = closureCompiler({
             js: __dirname + '/fixtures/**.js',
             compilation_level: 'SIMPLE',
             warning_level: 'VERBOSE'
@@ -206,10 +209,10 @@ describe('gulp-google-closure-compiler', function() {
             f.contents.toString().should.eql(fixturesCompiled);
           }))
           .pipe(assert.end(done));
-    });
+        });
 
-    it('should include js options before gulp.src files', done => {
-      gulp.src(__dirname + '/fixtures/two.js')
+        it('should include js options before gulp.src files', done => {
+          gulp.src(__dirname + '/fixtures/two.js')
           .pipe(closureCompiler({
             js: __dirname + '/fixtures/one.js',
             compilation_level: 'SIMPLE',
@@ -220,10 +223,10 @@ describe('gulp-google-closure-compiler', function() {
             f.contents.toString().should.eql(fixturesCompiled);
           }))
           .pipe(assert.end(done));
-    });
+        });
 
-    it('should support calling the compiler with an arguments array', done => {
-      const stream = closureCompiler([
+        it('should support calling the compiler with an arguments array', done => {
+          const stream = closureCompiler([
             '--js="' + __dirname + '/fixtures/**.js"',
             '--compilation_level=SIMPLE',
             '--warning_level=VERBOSE'
@@ -234,20 +237,10 @@ describe('gulp-google-closure-compiler', function() {
             f.contents.toString().should.eql(fixturesCompiled);
           }))
           .pipe(assert.end(done));
-    });
+        });
 
-    it('should generate no output without gulp.src files', done => {
-      gulp.src([])
-          .pipe(closureCompiler({
-            compilation_level: 'SIMPLE',
-            warning_level: 'VERBOSE'
-          }))
-          .pipe(assert.length(0))
-          .pipe(assert.end(done));
-    });
-
-    it('should compile without gulp.src files when .src() is called', done => {
-      closureCompiler({
+        it('should compile without gulp.src files when .src() is called', done => {
+          closureCompiler({
             compilation_level: 'SIMPLE',
             warning_level: 'VERBOSE',
             js: __dirname + '/fixtures/**.js'
@@ -258,45 +251,53 @@ describe('gulp-google-closure-compiler', function() {
             f.contents.toString().should.eql(fixturesCompiled);
           }))
           .pipe(assert.end(done));
-    });
+        });
+      }
 
-    it('should properly compose sourcemaps when multiple transformations are chained', done => {
-      gulp.src(['test/fixtures/one.js', 'test/fixtures/two.js'], {base: './'})
+      it('should generate no output without gulp.src files', done => {
+        gulp.src([])
+        .pipe(closureCompiler({
+          compilation_level: 'SIMPLE',
+          warning_level: 'VERBOSE'
+        }))
+        .pipe(assert.length(0))
+        .pipe(assert.end(done));
+      });
+
+      it('should properly compose sourcemaps when multiple transformations are chained', done => {
+        gulp.src(['test/fixtures/one.js', 'test/fixtures/two.js'], {base: './'})
           .pipe(sourcemaps.init())
           .pipe(closureCompiler({
             compilation_level: 'WHITESPACE_ONLY',
             warning_level: 'VERBOSE',
             formatting: 'PRETTY_PRINT',
-            module: [
-                'three:1',
-                'four:1:three'
-            ]
+            sourceMapIncludeContent: true
           }))
           .pipe(closureCompiler({
             compilation_level: 'SIMPLE',
             warning_level: 'QUIET',
             formatting: 'PRETTY_PRINT',
-            js_output_file: 'final.js'
+            js_output_file: 'final.js',
+            sourceMapIncludeContent: true
           }))
           .pipe(assert.first(f => {
             f.sourceMap.sources.should.containEql('test/fixtures/one.js');
             f.sourceMap.sources.should.containEql('test/fixtures/two.js');
           }))
           .pipe(assert.end(done));
-    });
-  });
+      });
 
-  describe('in streaming mode', () => {
-    it('should emit an error', done => {
-      gulp.src(__dirname + '/fixtures/**/*.js', {buffer: false})
-          .pipe(closureCompiler({
-            compilation_level: 'SIMPLE',
-            warning_level: 'VERBOSE'
-          }))
-          .on('error', err => {
-            err.message.should.eql('Streaming not supported');
-            done();
-          });
+      it('in streaming mode should emit an error', done => {
+        gulp.src(__dirname + '/fixtures/**/*.js', {buffer: false})
+        .pipe(closureCompiler({
+          compilation_level: 'SIMPLE',
+          warning_level: 'VERBOSE'
+        }))
+        .on('error', err => {
+          err.message.should.eql('Streaming not supported');
+          done();
+        });
+      });
     });
   });
 });

--- a/test/node.js
+++ b/test/node.js
@@ -24,82 +24,106 @@
 
 const should = require('should');
 const compilerPackage = require('../');
-const Compiler = compilerPackage.compiler;
+const {compiler: Compiler, jsCompiler} = compilerPackage;
 require('mocha');
 
 process.on('unhandledRejection', e => { throw e; });
 
 describe('closure-compiler node bindings', () => {
-  it('should have a static property for the jar path', () => {
-    Compiler.COMPILER_PATH.should.endWith('/compiler.jar');
-  });
-
-  it('should have a static property for the contrib folder', () => {
-    Compiler.CONTRIB_PATH.should.endWith('/contrib');
-  });
-
-  it('should error when java is not in the path', function(done) {
-    this.slow(1000);
-
-    const compiler = new Compiler({ version: true});
-    compiler.javaPath = 'DOES_NOT_EXIST';
-    compiler.run(function(exitCode, stdout, stderr) {
-      exitCode.should.not.eql(0);
-      stderr.indexOf('Is java in the path?').should.be.aboveOrEqual(0);
-      done();
-    });
-  });
-
-  it('should normalize an options object to an arguments array', () => {
-    const compiler = new Compiler({
-      one: true,
-      two: 'two',
-      three: ['one', 'two', 'three']
+  describe('java version', () => {
+    it('should have a static property for the jar path', () => {
+      Compiler.COMPILER_PATH.should.endWith('/compiler.jar');
     });
 
-    const expectedArray = ['-jar', Compiler.COMPILER_PATH, '--one=true', '--two=two',
+    it('should have a static property for the contrib folder', () => {
+      Compiler.CONTRIB_PATH.should.endWith('/contrib');
+    });
+
+    it('should error when java is not in the path', function (done) {
+      this.slow(1000);
+
+      const compiler = new Compiler({version: true});
+      compiler.javaPath = 'DOES_NOT_EXIST';
+      compiler.run(function (exitCode, stdout, stderr) {
+        exitCode.should.not.eql(0);
+        stderr.indexOf('Is java in the path?').should.be.aboveOrEqual(0);
+        done();
+      });
+    });
+
+    it('should normalize an options object to an arguments array', () => {
+      const compiler = new Compiler({
+        one: true,
+        two: 'two',
+        three: ['one', 'two', 'three']
+      });
+
+      const expectedArray = ['-jar', Compiler.COMPILER_PATH, '--one=true', '--two=two',
         '--three=one', '--three=two', '--three=three'];
-    compiler.commandArguments.length.should.eql(expectedArray.length);
-    compiler.commandArguments.forEach((item, index) => {
-      expectedArray[index].should.eql(item);
-    });
-  });
-
-  it('should prepend the -jar argument and compiler path when configured by array', () => {
-    const expectedArray = ['-jar', Compiler.COMPILER_PATH, '--one=true', '--two=two',
-      '--three=one', '--three=two', '--three=three'];
-
-    const compiler = new Compiler(expectedArray.slice(2));
-
-    compiler.commandArguments.length.should.eql(expectedArray.length);
-    compiler.commandArguments.forEach((item, index) => {
-      expectedArray[index].should.eql(item);
-    });
-  });
-
-  describe('extra command arguments', () => {
-    it('should include initial command arguments when configured by an options object', () => {
-      const expectedArray = ['-Xms2048m', '-jar', Compiler.COMPILER_PATH, '--one=true', '--two=two',
-        '--three=one', '--three=two', '--three=three'];
-
-      const compiler = new Compiler(expectedArray.slice(3), expectedArray.slice(0, 1));
-
       compiler.commandArguments.length.should.eql(expectedArray.length);
-      compiler.commandArguments.forEach(function(item, index) {
+      compiler.commandArguments.forEach((item, index) => {
         expectedArray[index].should.eql(item);
       });
     });
 
-    it('should include initial command arguments when configured by array', () => {
-      const expectedArray = ['-Xms2048m', '-jar', Compiler.COMPILER_PATH, '--one=true', '--two=two',
+    it('should prepend the -jar argument and compiler path when configured by array', () => {
+      const expectedArray = ['-jar', Compiler.COMPILER_PATH, '--one=true', '--two=two',
         '--three=one', '--three=two', '--three=three'];
 
-      const compiler = new Compiler(expectedArray.slice(3), expectedArray.slice(0, 1));
+      const compiler = new Compiler(expectedArray.slice(2));
 
       compiler.commandArguments.length.should.eql(expectedArray.length);
-      compiler.commandArguments.forEach(function(item, index) {
+      compiler.commandArguments.forEach((item, index) => {
         expectedArray[index].should.eql(item);
       });
+    });
+
+    describe('extra command arguments', () => {
+      it('should include initial command arguments when configured by an options object', () => {
+        const expectedArray = ['-Xms2048m', '-jar', Compiler.COMPILER_PATH, '--one=true', '--two=two',
+          '--three=one', '--three=two', '--three=three'];
+
+        const compiler = new Compiler(expectedArray.slice(3), expectedArray.slice(0, 1));
+
+        compiler.commandArguments.length.should.eql(expectedArray.length);
+        compiler.commandArguments.forEach(function (item, index) {
+          expectedArray[index].should.eql(item);
+        });
+      });
+
+      it('should include initial command arguments when configured by array', () => {
+        const expectedArray = ['-Xms2048m', '-jar', Compiler.COMPILER_PATH, '--one=true', '--two=two',
+          '--three=one', '--three=two', '--three=three'];
+
+        const compiler = new Compiler(expectedArray.slice(3), expectedArray.slice(0, 1));
+
+        compiler.commandArguments.length.should.eql(expectedArray.length);
+        compiler.commandArguments.forEach(function (item, index) {
+          expectedArray[index].should.eql(item);
+        });
+      });
+    });
+  });
+
+  describe('javascript version', () => {
+    it('should have a static property for the contrib folder', () => {
+      jsCompiler.CONTRIB_PATH.should.endWith('/contrib');
+    });
+
+    it('should normalize arguments to camel case', () => {
+      const compiler = new jsCompiler({
+        one_bar: true,
+        two_baz: 'two',
+        three_foo_bar_baz: ['one', 'two', 'three']
+      });
+
+      const expectedFlags = ['oneBar', 'twoBaz', 'threeFooBarBaz'];
+      Object.keys(compiler.flags).forEach(flag => {
+        const flagIndex = expectedFlags.indexOf(flag);
+        flagIndex.should.be.aboveOrEqual(0);
+        expectedFlags.splice(flagIndex, 1);
+      });
+      expectedFlags.length.should.eql(0);
     });
   });
 });


### PR DESCRIPTION
Support adding the GWT version of the compiler to this package. Users should be able to switch between versions with toggling an option.

Depends on:

 - https://github.com/google/closure-compiler/pull/2921
 - https://github.com/google/closure-compiler/pull/2922

Build the GWT version and copy `jscomp.js` to the root of the project. All tests should pass.

Left to do:

 - [ ] Add build and deployment instructions
 - [ ] Update readme
 - [ ] Support the module flag
 - [ ] Add webpack info