### PR TITLE
Ship jscomp.js with the NPM bundle.

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "compiler.jar",
     "cli.js",
     "index.js",
+    "jscomp.js",
     "package.json",
     "contrib/",
     "README.md"


### PR DESCRIPTION
After upgrading to `google-closure-compiler@^20180610.0.0`, attempting to import the Java compiler throws an error that `jscomp.js` cannot be found. It is indeed missing from the module, both when installed with NPM and when installed with Yarn. Since I see it's already built in CI, I _think_ this should be all you need to get it included.