### PR TITLE
Update README.md with Rollup Plugin Reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ The compiler package also includes build tool plugins for [Grunt](http://gruntjs
  * [Grunt Plugin](https://github.com/google/closure-compiler-npm/blob/master/docs/grunt.md)
  * [Gulp Plugin](https://github.com/google/closure-compiler-npm/blob/master/docs/gulp.md)
  * [Webpack Plugin](https://github.com/webpack-contrib/closure-webpack-plugin)
+ * [Rollup Plugin](https://github.com/ampproject/rollup-plugin-closure-compiler)
 
 ## Advanced Java Version Usage
 

--- a/README.md
+++ b/README.md
@@ -76,12 +76,14 @@ certain arguments:
 ```
 
 ## Build Tool Plugins
-The compiler package also includes build tool plugins for [Grunt](http://gruntjs.com/) and
-[Gulp](http://gulpjs.com/). There is also an [official webpack plugin](https://www.npmjs.com/package/closure-webpack-plugin).
+The compiler package also includes build tool plugins for [Grunt](http://gruntjs.com/) and [Gulp](http://gulpjs.com/). There is also an [official webpack plugin](https://www.npmjs.com/package/closure-webpack-plugin).
 
  * [Grunt Plugin](https://github.com/google/closure-compiler-npm/blob/master/docs/grunt.md)
  * [Gulp Plugin](https://github.com/google/closure-compiler-npm/blob/master/docs/gulp.md)
  * [Webpack Plugin](https://github.com/webpack-contrib/closure-webpack-plugin)
+
+### Community Maintained Plugins
+Additionally, community members have created plugins leveraging this library.
  * [Rollup Plugin](https://github.com/ampproject/rollup-plugin-closure-compiler)
 
 ## Advanced Java Version Usage


### PR DESCRIPTION
There is now a Rollup plugin for Closure Compiler leveraging `closure-compiler-npm`. Thought it might make sense to list it here as well.