### PR TITLE
Support the native graal packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 node_modules
 npm-debug.log
-compiler.jar
-contrib/
-jscomp.js
+/compiler.jar
+/contrib/
+/jscomp.js

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 npm-debug.log
 compiler.jar
 contrib/
+jscomp.js

--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ The simplest way to invoke the compiler (e.g. if you're just trying it out) is w
 
     npx google-closure-compiler --js=my_program.js --js_output_file=out.js
 
+The npx version will attempt to detect the best platform to use. You can also specify the platform
+with the special `--platform` flag.
+
 ### Installation
 
 ```

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You may also post in the
 
 *Please don't cross post to both Stackoverflow and Closure Compiler Discuss.*
 
-The compiler is distributed as a Java jar, a JavaScript library. Mac OS and Linux also have native binaries.
+The compiler is distributed as a Java jar and a JavaScript library. Mac OS and Linux also have native binaries.
 
 ### Native Binary Version
 On Mac OS or Linux, optional dependencies will install a native binary of the compiler.

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ const compiler = new Compiler({args});
 ```
 
 ### Running the compiler using nailgun
-*Note: nailgun users are encouraged to try the native binary viersions where available.*
+*Note: nailgun users are encouraged to try the native binary versions where available.*
 
 This gets around the long startup time of Google Closure Compiler using
 [Nailgun](https://github.com/facebook/nailgun), which runs a single java process in the background

--- a/README.md
+++ b/README.md
@@ -22,7 +22,12 @@ You may also post in the
 
 *Please don't cross post to both Stackoverflow and Closure Compiler Discuss.*
 
-The compiler is distributed as a Java jar or as a JavaScript library.
+The compiler is distributed as a Java jar, a JavaScript library. Mac OS and Linux also have native binaries.
+
+### Native Binary Version
+On Mac OS or Linux, optional dependencies will install a native binary of the compiler.
+Native binaries offer faster compile times without requiring Java to be installed and available.
+Compilations with a very large number of source files may be slightly slower than the java version.
 
 ### Java Version
 Requires java to be installed and in the path. Using the java version typically results in faster compilation times.
@@ -98,6 +103,8 @@ const compiler = new Compiler({args});
 ```
 
 ### Running the compiler using nailgun
+*Note: nailgun users are encouraged to try the native binary viersions where available.*
+
 This gets around the long startup time of Google Closure Compiler using
 [Nailgun](https://github.com/facebook/nailgun), which runs a single java process in the background
 and keeps all of the classes loaded.

--- a/build_compiler.js
+++ b/build_compiler.js
@@ -6,6 +6,7 @@ const ncp = require('ncp');
 const Semver = require('semver');
 const version = require('./package.json').version;
 const fs = require('fs');
+const compilerVersionMatch = require('./version-match');
 const packageVer = new Semver(version);
 
 const mavenVersion = 'v' + version.split('.')[0];
@@ -25,7 +26,7 @@ if (compilerJarStats && compilerJarStats.isFile()) {
   for (let line of versionOutput.output) {
     if (line) {
       const lineString = line.toString();
-      const versionParts = /^Version: v(\d+)(?:[-\.][-a-z0-9]+)?$/m.exec(lineString);
+      const versionParts = compilerVersionMatch.exec(lineString);
       if (versionParts) {
         shouldDownloadCompiler = parseInt(versionParts[1], 10) < packageVer.major;
       }

--- a/build_compiler.js
+++ b/build_compiler.js
@@ -13,6 +13,8 @@ const url =
     'https://repo1.maven.org/maven2/com/google/javascript/closure-compiler/'
     + mavenVersion + '/closure-compiler-' + mavenVersion + '.jar';
 
+console.log(process.platform, process.arch);
+
 let shouldDownloadCompiler = true;
 let compilerJarStats = null;
 try {

--- a/build_compiler.js
+++ b/build_compiler.js
@@ -23,7 +23,7 @@ if (compilerJarStats && compilerJarStats.isFile()) {
   for (let line of versionOutput.output) {
     if (line) {
       const lineString = line.toString();
-      const versionParts = /^Version: v(\d+)$/m.exec(lineString);
+      const versionParts = /^Version: v(\d+)(?:[-\.][-a-z0-9]+)?$/m.exec(lineString);
       if (versionParts) {
         shouldDownloadCompiler = parseInt(versionParts[1], 10) < packageVer.major;
       }

--- a/build_compiler.js
+++ b/build_compiler.js
@@ -50,6 +50,7 @@ ncp('./compiler/contrib', './contrib', err => {
 });
 
 if (shouldDownloadCompiler) {
+  spawnSync('mvn', ['clean']);
   const gwtBuild = spawn(
       'mvn', ['-DskipTests', '-f', 'pom-gwt.xml', 'clean', 'install'], {
         cwd: './compiler',
@@ -63,7 +64,10 @@ if (shouldDownloadCompiler) {
       process.exit(1);
       return;
     }
-    ncp('./compiler/target/closure-compiler-gwt-1.0-SNAPSHOT/jscomp/jscomp.js', './jscomp.js', err => {
+    const targetFiles = fs.readdirSync('./compiler/target');
+    const gwtDir = targetFiles.find(filePath =>
+      /^closure-compiler-gwt-/.test(filePath) && !/\.war$/.test(filePath));
+    ncp(`./compiler/target/${gwtDir}/jscomp/jscomp.js`, './jscomp.js', err => {
       if (err) {
         throw new Error(err);
       }

--- a/cli.js
+++ b/cli.js
@@ -133,7 +133,10 @@ if (platform !== 'javascript') {
         }
 
         process.exitCode = process.exitCode || exitCode;
-        process.exit();
       });
+    })
+    .catch(e => {
+      console.error(e);
+      process.exitCode = process.exitCode || 1;
     });
 }

--- a/cli.js
+++ b/cli.js
@@ -1,20 +1,128 @@
 #!/usr/bin/env node
-'use strict'
-const spawnSync = require('child_process').spawnSync
-const COMPILER_PATH = require('./index.js').compiler.COMPILER_PATH
-const result = spawnSync(
-  'java',
-  ['-jar', COMPILER_PATH].concat(process.argv.slice(2)),
-  {stdio: 'inherit'}
-)
-if (result.error) {
-  if (result.error.code === 'ENOENT') {
-    console.error('Could not find "java" in your PATH.')
-  } else {
-    console.error(result.error.message)
-  }
-  process.exit(1)
+'use strict';
+const fs = require('fs');
+const {getNativeImagePath, getFirstSupportedPlatform, parseCliFlags} = require('./lib/utils');
+
+const compilerFlags = parseCliFlags(process.argv.slice(2));
+let platform;
+if (compilerFlags.platform) {
+  platform = compilerFlags.platform;
+  delete compilerFlags.platform;
 } else {
-  process.exit(result.status)
+  platform = getFirstSupportedPlatform(['native', 'java', 'javascript']);
 }
 
+if (platform !== 'javascript') {
+  const Compiler = require('./lib/node/closure-compiler');
+  let args = process.argv.slice(2);
+  for (let i = 0; i < args.length; i++) {
+    if (/^--platform/.test(args[i])) {
+      let delCount = 1;
+      if (args[i].indexOf('=') < 0 && args.length > i + 1) {
+        delCount++;
+      }
+      args.splice(i, delCount);
+      break;
+    }
+  }
+
+  const compiler = new Compiler(args);
+
+  compiler.spawnOptions = {stdio: 'inherit'};
+  if (platform === 'native') {
+    compiler.JAR_PATH = null;
+    compiler.javaPath = getNativeImagePath();
+  }
+
+  compiler.run((exitCode) => {
+    process.exit(exitCode);
+  });
+} else {
+  if (compilerFlags.help === true) {
+    console.log('Sample usage: --compilation_level (-O) VAL --externs VAL --js VAL --js_output_file VAL --warning_level (-W) [QUIET | DEFAULT | VERBOSE]');
+    console.log('See https://github.com/google/closure-compiler/wiki/Flags-and-Options for the full list of flags');
+    process.exit(0);
+  }
+
+  if (compilerFlags.version === true) {
+    const {version} = require('./package.json');
+    console.log(`Version: ${version}`);
+    process.exit(0);
+  }
+
+  let inputFilePromises = [];
+  let waitOnStdIn = true;
+  if (compilerFlags.js) {
+    waitOnStdIn = false;
+    if (!Array.isArray(compilerFlags.js)) {
+      compilerFlags.js = [compilerFlags.js];
+    }
+    inputFilePromises = compilerFlags.js.map(path =>
+        new Promise((resolve, reject) =>
+            fs.readFile(path, 'utf8', (err, src) => err ? reject(err) : resolve({src, path})))
+        .catch(e => console.error(e)));
+
+    delete compilerFlags.js;
+  }
+  let externFilePromises = [];
+  if (compilerFlags.externs) {
+    if (!Array.isArray(compilerFlags.externs)) {
+      compilerFlags.externs = [compilerFlags.externs];
+    }
+    externFilePromises = compilerFlags.externs.map(path =>
+        new Promise((resolve, reject) =>
+            fs.readFile(path, 'utf8', (err, src) => err ? reject(err) : resolve({src, path})))
+        .catch(e => console.error(e)));
+
+    delete compilerFlags.externs;
+  }
+
+  const inputsReadPromise = inputFilePromises.length > 0 ? Promise.all(inputFilePromises) : Promise.resolve([]);
+  const externsReadPromise = externFilePromises.length > 0 ? Promise.all(externFilePromises) : Promise.resolve([]);
+
+  Promise.all([inputsReadPromise, externsReadPromise])
+    .then(([inputFiles, externs]) => {
+      if (externs.length > 0) {
+        compilerFlags.externs = externs;
+      } else {
+        delete compilerFlags.externs;
+      }
+
+      if (!waitOnStdIn) {
+        return inputFiles;
+      } else {
+        return new Promise(resolve => {
+          let stdInData = '';
+          process.stdin.on('readable', () => {
+            const chunk = process.stdin.read();
+            if (chunk !== null) {
+              stdInData += chunk;
+            }
+          });
+          process.stdin.on('end', () => {
+            if (stdInData.length > 0) {
+              inputFiles.push({
+                path: 'stdin',
+                src: stdInData
+              });
+            }
+            resolve(inputFiles);
+          });
+        });
+      }
+    })
+    .then(inputFiles => {
+      const Compiler = require('./lib/node/closure-compiler-js');
+      const compiler = new Compiler(compilerFlags);
+      compiler.run(inputFiles, (exitCode, compiledFiles, errors) => {
+        if (errors && errors.length > 0) {
+          console.error(errors);
+        }
+        if (compiledFiles.length === 1 && compiledFiles[0].path === 'compiled.js' && !compilerFlags['js_output_file']) {
+          console.log(compiledFiles[0].src);
+        }
+
+        process.exit(exitCode);
+      });
+    });
+}

--- a/deployments.md
+++ b/deployments.md
@@ -2,13 +2,19 @@
 
 *You now need yarn installed - `npm install -g yarn`*
 
- 1. Update the compiler submodule pointer to the tagged release.
+ 1. Update the package version number in `package.json` at
+    https://github.com/chadkillingsworth/closure-compiler-graal.
+    The major version should be equal to the compiler version and the minor and patch numbers should be `0`.
+    Example: 20160619.0.0.
+    Wait for Travis to publish the new versions.
+ 2. Update the compiler submodule pointer to the tagged release.
      * change to the '/compiler' folder
      * `git checkout` the correct tag/commit
      * change back to the root folder and commit this change
- 2. Update the package version number in `package.json`. The major version should be equal to the compiler version
+ 3. Update the package version number in `package.json`. The major version should be equal to the compiler version
     and the minor and patch numbers should be `0`. Example: 20160619.0.0.
- 3. Run the tests: `yarn install && yarn test`.
- 3. Commit the changes from steps 1 & 2 and tag the commit.
- 4. Push the changes and tag. If the tests all pass, Travis-CI will automatically publish the new release to the
+    Update the native package versions in the `optionalDependencies`.
+ 4. Run the tests: `yarn install && yarn test`.
+ 5. Commit the changes from steps 1 & 2 and tag the commit.
+ 6. Push the changes and tag. If the tests all pass, Travis-CI will automatically publish the new release to the
    npm registry.

--- a/docs/grunt.md
+++ b/docs/grunt.md
@@ -5,18 +5,15 @@ Task targets, files and options may be specified according to the grunt
 
 Include the plugin in your Gruntfile.js:
 
-## Java Version of Closure Compiler
 ```js
-require('google-closure-compiler').grunt(grunt);
+require('google-closure-compiler').grunt(grunt, {
+  platform: ['native', 'java', 'javascript']
+});
 // The load-grunt-tasks plugin won't automatically load closure-compiler
 ```
 
-## JS Version of Closure Compiler
-
-```js
-require('google-closure-compiler').grunt(grunt, 'javascript');
-// The load-grunt-tasks plugin won't automatically load closure-compiler
-```
+The `platform` option specifies whether to use the `java`, `javascript` or `native` versions of the compiler.
+The option can be either a string or an array where the first supported platform will be used:
 
 ## Basic Configuration Example:
 
@@ -74,5 +71,8 @@ Some users may wish to pass the java vm extra arguments - such as to specify the
 be allocated. Both the grunt and gulp plugins support this.
 
 ```js
-require('google-closure-compiler').grunt(grunt, ['-Xms2048m']);
+require('google-closure-compiler').grunt(grunt, {
+  platform: 'java',
+  extraArguments: ['-Xms2048m']
+});
 ```

--- a/docs/gulp.md
+++ b/docs/gulp.md
@@ -6,8 +6,6 @@ Options are a direct match to the compiler flags without the leading "--".
 
 ## Basic Configuration Example:
 
-### Java Version
-
 ```js
 const closureCompiler = require('google-closure-compiler').gulp();
 
@@ -20,29 +18,15 @@ gulp.task('js-compile', function () {
           language_out: 'ECMASCRIPT5_STRICT',
           output_wrapper: '(function(){\n%output%\n}).call(this)',
           js_output_file: 'output.min.js'
+        }, {
+          platform: ['native', 'java', 'javascript']
         }))
       .pipe(gulp.dest('./dist/js'));
 });
 ```
 
-### JavaScript Version
-
-```js
-const closureCompiler = require('google-closure-compiler').gulp({jsMode: true});
-
-gulp.task('js-compile', function () {
-  return gulp.src('./src/js/**/*.js', {base: './'})
-      .pipe(closureCompiler({
-          compilation_level: 'SIMPLE',
-          warning_level: 'VERBOSE',
-          language_in: 'ECMASCRIPT6_STRICT',
-          language_out: 'ECMASCRIPT5_STRICT',
-          output_wrapper: '(function(){\n%output%\n}).call(this)',
-          js_output_file: 'output.min.js'
-        }))
-      .pipe(gulp.dest('./dist/js'));
-});
-```
+The `platform` option specifies whether to use the `java`, `javascript` or `native` versions of the compiler.
+The option can be either a string or an array where the first supported platform will be used:
 
 ## Use without gulp.src (Java Version Only)
 Gulp files are all read into memory, transformed into a JSON stream, and piped through the

--- a/lib/grunt/index.js
+++ b/lib/grunt/index.js
@@ -52,7 +52,7 @@ module.exports = (grunt, pluginOptions) => {
   }
 
   if (!platforms) {
-    platforms = ['java', 'javascript'];
+    platforms = ['native', 'java', 'javascript'];
   }
   const platform = getFirstSupportedPlatform(platforms);
 

--- a/lib/grunt/index.js
+++ b/lib/grunt/index.js
@@ -26,12 +26,35 @@
 
 'use strict';
 
-module.exports = (grunt, extraArguments) => {
+module.exports = (grunt, pluginOptions) => {
   const chalk = require('chalk');
   const VinylStream = require('./vinyl-stream');
   const Transform = require('stream').Transform;
   const gulpCompilerOptions = {};
   const gulp = require('gulp');
+  const {getFirstSupportedPlatform} = require('../utils');
+
+  let extraArguments;
+  let platforms;
+  if (pluginOptions) {
+    if (Array.isArray(extraArguments)) {
+      extraArguments = pluginOptions;
+    } else if (pluginOptions === 'javascript') {
+      platforms = ['javascript'];
+    } else {
+      if (pluginOptions.platform) {
+        platforms = Array.isArray(pluginOptions.platform) ? pluginOptions.platform : [pluginOptions.platform];
+      }
+      if (pluginOptions.extraArguments) {
+        extraArguments = pluginOptions.extraArguments;
+      }
+    }
+  }
+
+  if (!platforms) {
+    platforms = ['java', 'javascript'];
+  }
+  const platform = getFirstSupportedPlatform(platforms);
 
   /**
    * @param {Array<string>}|null} files
@@ -60,11 +83,10 @@ module.exports = (grunt, extraArguments) => {
 
     return new Promise(function(resolve, reject) {
       let stream;
-      const args = Object.assign({}, {jsMode: extraArguments === 'javascript'});
+      const args = {};
       let gulpOpts;
-      if (args.jsMode) {
+      if (platform === 'javascript') {
         gulpOpts = Object.assign({}, gulpCompilerOptions, {
-          jsMode: true,
           logger: grunt.log,
           pluginName: 'grunt-google-closure-compiler'
         });
@@ -87,7 +109,7 @@ module.exports = (grunt, extraArguments) => {
         // the compiler task
         stream = new VinylStream(files, {base: process.cwd()})
             .pipe(gulpCompiler(options, compilerOpts));
-        if (args.jsMode) {
+        if (platform === 'javascript') {
           stream = stream.on('error', err => {
             hadError = true;
             reject(err);
@@ -98,7 +120,7 @@ module.exports = (grunt, extraArguments) => {
         // --js flags and invoke the compiler without any grunt inputs.
         // Manually end the stream to force compilation to begin.
         stream = gulpCompiler(options, compilerOpts);
-        if (args.jsMode) {
+        if (platform === 'javascript') {
           stream = stream.on('error', err => {
             hadError = true;
             reject(err);
@@ -133,7 +155,6 @@ module.exports = (grunt, extraArguments) => {
       const args = opts.args;
 
       delete opts.args;
-      delete opts.jsMode;
 
       return {
         args,
@@ -162,7 +183,7 @@ module.exports = (grunt, extraArguments) => {
         options.compilerOpts.js_output_file = f.dest;
       }
 
-      compileTasks.push(compilationPromise(src, options.args || options.compilerOpts, {jsMode: options.jsMode})
+      compileTasks.push(compilationPromise(src, options.args || options.compilerOpts, {platform})
           .then(function () {}, function(err) {
             throw err;
           }));
@@ -172,7 +193,7 @@ module.exports = (grunt, extraArguments) => {
     // --js flags are present and we want to run the compiler anyway.
     if (taskObject.files.length === 0) {
       const options = getCompilerOptions();
-      compileTasks.push(compilationPromise(null, options.args || options.compilerOpts, {jsMode: options.jsMode}));
+      compileTasks.push(compilationPromise(null, options.args || options.compilerOpts, {platform}));
     }
 
     // Multiple invocations of the compiler can occur for a single task target. Wait until

--- a/lib/gulp/index.js
+++ b/lib/gulp/index.js
@@ -42,14 +42,15 @@ module.exports = function(initOptions) {
   const filesToJson = require('./concat-to-json');
   const jsonToVinyl = require('./json-to-vinyl');
   const stream = require('stream');
+  const {getNativeImagePath, getFirstSupportedPlatform} = require('../utils');
   /** @const */
   const PLUGIN_NAME = 'gulp-google-closure-compiler';
 
-  const extraCommandArguments = initOptions ? initOptions.extraArguments : undefined;
-  const jsMode = Boolean(initOptions && initOptions.jsMode);
   const applySourceMap = require('vinyl-sourcemaps-apply');
   const chalk = require('chalk');
   const File = require('vinyl');
+
+  const extraCommandArguments = initOptions ? initOptions.extraArguments : undefined;
 
   let PluginError;
   try {
@@ -65,7 +66,9 @@ module.exports = function(initOptions) {
     gulpLog = console;
   }
 
-  const Compiler = jsMode ? require('../node/closure-compiler-js') : require('../node/closure-compiler');
+  function getCompiler(platform) {
+    return platform === 'javascript' ? require('../node/closure-compiler-js') : require('../node/closure-compiler');
+  }
 
   class CompilationStream extends stream.Transform {
     constructor(compilationOptions, pluginOptions) {
@@ -79,6 +82,13 @@ module.exports = function(initOptions) {
 
       this.fileList_ = [];
       this._streamInputRequired = pluginOptions.requireStreamInput !== false;
+
+      const jsMode = Boolean(initOptions && initOptions.jsMode);
+      let platforms = (pluginOptions && pluginOptions.platform) || (jsMode ? ['javascript'] : ['java', 'javascript']);
+      if (!Array.isArray(platforms)) {
+        platforms = [platforms];
+      }
+      this.platform = getFirstSupportedPlatform(platforms);
     }
 
     src() {
@@ -106,7 +116,7 @@ module.exports = function(initOptions) {
         return;
       }
 
-      if (file.sourceMap && jsMode) {
+      if (file.sourceMap && this.platform === 'javascript') {
         this.compilationOptions_.createSourceMap = true;
       }
 
@@ -131,8 +141,13 @@ module.exports = function(initOptions) {
         // list if no files were piped into this plugin.
         jsonFiles = [];
       }
+      const Compiler = getCompiler(this.platform);
       const compiler = new Compiler(this.compilationOptions_, extraCommandArguments);
-      if (jsMode) {
+      if (this.platform === 'native') {
+        compiler.JAR_PATH = null;
+        compiler.javaPath = getNativeImagePath();
+      }
+      if (this.platform === 'javascript') {
         let compilerProcess;
         try {
           compilerProcess = compiler.run(jsonFiles);

--- a/lib/gulp/index.js
+++ b/lib/gulp/index.js
@@ -143,10 +143,6 @@ module.exports = function(initOptions) {
       }
       const Compiler = getCompiler(this.platform);
       const compiler = new Compiler(this.compilationOptions_, extraCommandArguments);
-      if (this.platform === 'native') {
-        compiler.JAR_PATH = null;
-        compiler.javaPath = getNativeImagePath();
-      }
       if (this.platform === 'javascript') {
         let compilerProcess;
         try {
@@ -163,6 +159,10 @@ module.exports = function(initOptions) {
             errors.join('\n\n'));
         cb();
       } else {
+        if (this.platform === 'native') {
+          compiler.JAR_PATH = null;
+          compiler.javaPath = getNativeImagePath();
+        }
         let stdOutData = '';
         let stdErrData = '';
 

--- a/lib/gulp/index.js
+++ b/lib/gulp/index.js
@@ -84,7 +84,7 @@ module.exports = function(initOptions) {
       this._streamInputRequired = pluginOptions.requireStreamInput !== false;
 
       const jsMode = Boolean(initOptions && initOptions.jsMode);
-      let platforms = (pluginOptions && pluginOptions.platform) || (jsMode ? ['javascript'] : ['java', 'javascript']);
+      let platforms = (pluginOptions && pluginOptions.platform) || (jsMode ? ['javascript'] : ['native', 'java', 'javascript']);
       if (!Array.isArray(platforms)) {
         platforms = [platforms];
       }

--- a/lib/node/closure-compiler.js
+++ b/lib/node/closure-compiler.js
@@ -78,13 +78,17 @@ class Compiler {
     let stdOutData = '';
     let stdErrData = '';
     if (callback) {
-      compileProcess.stdout.on('data', data => {
-        stdOutData += data;
-      });
+      if (compileProcess.stdout) {
+        compileProcess.stdout.on('data', data => {
+          stdOutData += data;
+        });
+      }
 
-      compileProcess.stderr.on('data', data => {
-        stdErrData += data;
-      });
+      if (compileProcess.stderr) {
+        compileProcess.stderr.on('data', data => {
+          stdErrData += data;
+        });
+      }
 
       compileProcess.on('close',  code => {
         if (code !== 0) {

--- a/lib/node/closure-compiler.js
+++ b/lib/node/closure-compiler.js
@@ -34,10 +34,11 @@ class Compiler {
    * @param {Array<String>=} extraCommandArgs
    */
   constructor(args, extraCommandArgs) {
-    this.commandArguments = (extraCommandArgs || []).slice();
+    this.commandArguments = [];
+    this.extraCommandArgs = extraCommandArgs;
 
     if (Compiler.JAR_PATH) {
-      this.commandArguments.push('-jar', Compiler.JAR_PATH);
+      this.JAR_PATH = Compiler.JAR_PATH;
     }
 
     if (Array.isArray(args)) {
@@ -62,10 +63,16 @@ class Compiler {
    * @return {child_process.ChildProcess}
    */
   run(callback) {
+    if (this.JAR_PATH) {
+      this.commandArguments.unshift('-jar', Compiler.JAR_PATH);
+      if (this.extraCommandArgs) {
+        this.commandArguments.unshift(...this.extraCommandArgs);
+      }
+    }
+
     if (this.logger) {
       this.logger(this.getFullCommand() + '\n');
     }
-
     let compileProcess = spawn(this.javaPath, this.commandArguments, this.spawnOptions);
 
     let stdOutData = '';

--- a/lib/node/closure-compiler.js
+++ b/lib/node/closure-compiler.js
@@ -79,12 +79,17 @@ class Compiler {
     let stdErrData = '';
     if (callback) {
       if (compileProcess.stdout) {
+        compileProcess.stdout.setEncoding('utf8');
         compileProcess.stdout.on('data', data => {
           stdOutData += data;
+        });
+        compileProcess.stdout.on('error', err => {
+          stdErrData += err.toString();
         });
       }
 
       if (compileProcess.stderr) {
+        compileProcess.stderr.setEncoding('utf8');
         compileProcess.stderr.on('data', data => {
           stdErrData += data;
         });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,44 @@
+'use strict';
+
+function getNativeImagePath() {
+  if (process.platform === 'darwin') {
+    try {
+      return require('google-closure-compiler-osx');
+    } catch (e) {
+      return;
+    }
+  }
+  try {
+    return require('google-closure-compiler-linux');
+  } catch (e) {
+  }
+}
+
+function getFirstSupportedPlatform(platforms) {
+  const platform = platforms.find((platform, index) => {
+    switch (platform.toLowerCase()) {
+      case "java":
+        if (index === platforms.length - 1) {
+          return true;
+        }
+        return process.env.JAVA_HOME;
+
+      case "javascript":
+        return true;
+
+      case "native":
+        if (getNativeImagePath()) {
+          return true;
+        }
+    }
+  });
+  if (!platform) {
+    throw new Error('No supported platform for closure-compiler found.');
+  }
+  return platform;
+}
+
+module.exports = {
+  getNativeImagePath,
+  getFirstSupportedPlatform
+};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -38,7 +38,71 @@ function getFirstSupportedPlatform(platforms) {
   return platform;
 }
 
+/**
+ * Parse cli provided flags and create an object
+ *
+ * @param {!Array<string>} flags
+ * @return {!Object<string, (string|boolean|Array<string>)>}
+ */
+function parseCliFlags(flags) {
+  const flagShortcuts = new Map([
+    ['-O', 'compilation_level'],
+    ['-W', 'warning_level']
+  ]);
+
+  const compilerFlags = {};
+  let currentFlag;
+  const addFlagValue = flagValue => {
+    if (!currentFlag) {
+      currentFlag = 'js';
+    }
+
+    if (compilerFlags[currentFlag] && !Array.isArray(compilerFlags[currentFlag])) {
+      compilerFlags[currentFlag] = [compilerFlags[currentFlag], flagValue];
+    } else {
+      compilerFlags[currentFlag] = flagValue;
+    }
+    currentFlag = undefined;
+  };
+  flags.forEach(flagOrValue => {
+    let nextFlag;
+    let maybeFlag = flagOrValue;
+    let eqIndex = flagOrValue.indexOf('=');
+    if (eqIndex > 0) {
+      maybeFlag = maybeFlag.substr(0, eqIndex);
+    }
+    if (flagShortcuts.has(maybeFlag)) {
+      nextFlag = flagShortcuts.get(maybeFlag);
+      if (eqIndex > 0) {
+        nextFlag += flagOrValue.substr(eqIndex);
+      }
+    } else if (/^--/.test(maybeFlag)) {
+      nextFlag = flagOrValue.substr(2);
+    } else {
+      addFlagValue(flagOrValue);
+    }
+    if (nextFlag) {
+      if (currentFlag) {
+        addFlagValue(true);
+      }
+
+      eqIndex = nextFlag.indexOf('=');
+      if (eqIndex > 0) {
+        currentFlag = nextFlag.substr(0, eqIndex);
+        addFlagValue(nextFlag.substr(eqIndex + 1));
+      } else {
+        currentFlag = nextFlag;
+      }
+    }
+  });
+  if (currentFlag) {
+    addFlagValue(true);
+  }
+  return compilerFlags;
+}
+
 module.exports = {
   getNativeImagePath,
-  getFirstSupportedPlatform
+  getFirstSupportedPlatform,
+  parseCliFlags
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "google-closure-compiler",
-  "version": "20180610.0.2",
+  "version": "20180610.0.3",
   "description": "Check, compile, optimize and compress Javascript with Closure-Compiler",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "google-closure-compiler",
-  "version": "20180610.0.3",
+  "version": "20180610.0.2",
   "description": "Check, compile, optimize and compress Javascript with Closure-Compiler",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,10 @@
     "vinyl": "^2.0.1",
     "vinyl-sourcemaps-apply": "^0.2.0"
   },
+  "optionalDependencies": {
+    "google-closure-compiler-linux": "^20180610.0.1",
+    "google-closure-compiler-osx": "^20180610.0.1"
+  },
   "devDependencies": {
     "gulp": "^3.9.0",
     "gulp-mocha": "6.0.0",

--- a/test/cli.js
+++ b/test/cli.js
@@ -120,7 +120,7 @@ describe('command line interface', function() {
           if (stdError.length > 0) {
             console.error(stdError);
           }
-          should(stdError.length).equal(0);
+          should(stdOut.indexOf("console.log")).above(-1);
           done();
         }
 
@@ -133,6 +133,7 @@ describe('command line interface', function() {
         function complete() {
           should(exitCode).equal(0);
           should(stdOut.length).above(0);
+          should(stdOut.indexOf('alert("hello world")')).above(-1);
           done();
         }
 

--- a/test/cli.js
+++ b/test/cli.js
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2018 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Tests for google-closure-compiler cli
+ *
+ * @author Chad Killingsworth (chadkillingsworth@gmail.com)
+ */
+
+'use strict';
+
+const should = require('should');
+const spawn = require('child_process').spawn;
+require('mocha');
+
+process.on('unhandledRejection', e => { throw e; });
+
+describe('command line interface', function() {
+  this.timeout(30000);
+  this.slow(10000);
+
+  const cliPath = require.resolve('../cli.js');
+  let stdOut = '';
+  let stdError = '';
+  let exitCode;
+  function runCmd(cmd, args, stdInData) {
+    return new Promise((resolve, reject) => {
+      const compilationProcess = spawn(cmd, args);
+      compilationProcess.stdout.setEncoding('utf8');
+      compilationProcess.stdout.on('data', data => {
+        stdOut += data;
+      });
+      compilationProcess.stdout.on('error', err => {
+        stdError += err.toString();
+      });
+
+      compilationProcess.stderr.setEncoding('utf8');
+      compilationProcess.stderr.on('data', data => {
+        stdError += data;
+      });
+
+      compilationProcess.on('close', code => {
+        exitCode = code;
+        if (code !== 0) {
+          reject();
+        }
+
+        resolve();
+      });
+
+      compilationProcess.on('error', err => {
+        reject(err);
+      });
+
+      if (stdInData) {
+        compilationProcess.stdin.setEncoding('utf8');
+        compilationProcess.stdin.end(stdInData);
+      }
+    });
+  }
+
+  it('chooses an acceptable platform automatically', done => {
+    function complete() {
+      should(exitCode).equal(0);
+      should(stdOut.length).above(0);
+      done();
+    }
+
+    runCmd(cliPath, ['--js', 'test/fixtures/one.js'])
+      .then(complete)
+      .catch(complete);
+  });
+
+  ['java', 'native', 'javascript'].forEach(platform => {
+    describe(`${platform} version`, function() {
+      beforeEach(() => {
+        stdOut = '';
+        stdError = '';
+      });
+      it('--help flag', done => {
+        function complete() {
+          should(stdOut.length).above(0);
+          should(stdError.length).equal(0);
+          should(exitCode).equal(0);
+          done();
+        }
+
+        runCmd(cliPath, [`--platform=${platform}`, '--help'])
+          .then(complete)
+          .catch(complete);
+      });
+
+      it('invalid flag', done => {
+        function complete() {
+          should(exitCode).not.equal(0);
+          done();
+        }
+
+        runCmd(cliPath, [`--platform=${platform}`, '--foo=bar', '--js=test/fixtures/one.js'])
+          .then(complete)
+          .catch(complete);
+      });
+
+      it('compile successfully', done => {
+        function complete() {
+          should(exitCode).equal(0);
+          should(stdOut.length).above(0);
+          if (stdError.length > 0) {
+            console.error(stdError);
+          }
+          should(stdError.length).equal(0);
+          done();
+        }
+
+        runCmd(cliPath, [`--platform=${platform}`, '--js=test/fixtures/one.js', '--use_types_for_optimization'])
+          .then(complete)
+          .catch(complete);
+      });
+
+      it('accept piped input', done => {
+        function complete() {
+          should(exitCode).equal(0);
+          should(stdOut.length).above(0);
+          done();
+        }
+
+        runCmd(cliPath, [`--platform=${platform}`], 'alert("hello world")')
+          .then(complete)
+          .catch(complete);
+      });
+    });
+  });
+});

--- a/test/cli.js
+++ b/test/cli.js
@@ -93,7 +93,6 @@ describe('command line interface', function() {
       it('--help flag', done => {
         function complete() {
           should(stdOut.length).above(0);
-          should(stdError.length).equal(0);
           should(exitCode).equal(0);
           done();
         }

--- a/test/compiler.js
+++ b/test/compiler.js
@@ -87,7 +87,8 @@ describe('compiler submodule', function() {
     const mvnVersion = 'v' + packageVer.major;
     let normalizedTag = currentTag;
     if (normalizedTag) {
-      normalizedTag = currentTag.replace(/^([a-z]+-)?v\d{8}(.*)$/, (match, g1, g2) => match.substr(g1.length, match.length - g1.length - g2.length));
+      normalizedTag = currentTag.replace(/^([a-z]+-)?v\d{8}(.*)$/,
+          (match, g1, g2) => match.substr((g1 || '').length, match.length - (g1 || '').length - (g2 || '').length));
     }
     should(normalizedTag).eql(mvnVersion)
   });

--- a/test/compiler.js
+++ b/test/compiler.js
@@ -27,7 +27,7 @@ const compilerPackage = require('../');
 const Compiler = compilerPackage.compiler;
 const packageInfo = require('../package.json');
 const Semver = require('semver');
-const compilerVersionExpr = /^Version: v(\d+)(?:[-\.][-a-z0-9]+)?$/m;
+const compilerVersionMatch = require('../version-match');
 const spawn = require('child_process').spawnSync;
 require('mocha');
 
@@ -45,7 +45,7 @@ describe('compiler.jar', function() {
   it('should not be a snapshot build', done => {
     const compiler = new Compiler({ version: true});
     compiler.run(function(exitCode, stdout, stderr) {
-      let versionInfo = (stdout || '').match(compilerVersionExpr);
+      let versionInfo = (stdout || '').match(compilerVersionMatch);
       should(versionInfo).not.be.eql(null);
       versionInfo = versionInfo || [];
       versionInfo.length.should.be.eql(2);
@@ -58,7 +58,7 @@ describe('compiler.jar', function() {
     const compiler = new Compiler({ version: true});
     const packageVer = new Semver(packageInfo.version);
     compiler.run(function(exitCode, stdout, stderr) {
-      let versionInfo = (stdout || '').match(compilerVersionExpr);
+      let versionInfo = (stdout || '').match(compilerVersionMatch);
       should(versionInfo).not.be.eql(null);
       versionInfo = versionInfo || [];
       versionInfo.length.should.be.eql(2);

--- a/test/grunt.js
+++ b/test/grunt.js
@@ -92,11 +92,15 @@ function getGruntTaskObject(fileObj, options, asyncDone) {
 }
 
 describe('grunt-google-closure-compiler', function() {
-  ['java', 'javascript'].forEach(mode => {
-    describe(`${mode} version`, function() {
-      const closureCompiler = require('../').grunt(mockGrunt, mode === 'javascript' ? mode : undefined);
+  ['java', 'native', 'javascript'].forEach(platform => {
+    describe(`${platform} version`, function() {
+      let closureCompiler;
       this.slow(1000);
       this.timeout(10000);
+
+      beforeEach(() => {
+        closureCompiler = require('../').grunt(mockGrunt, {platform});
+      });
 
       it('should emit an error for invalid options', done => {
         let didFail = false;
@@ -190,7 +194,7 @@ describe('grunt-google-closure-compiler', function() {
         closureCompiler.call(taskObj);
       });
 
-      if (mode !== 'javascript') {
+      if (platform !== 'javascript') {
         it('should run when grunt provides no files', function (done) {
           this.timeout(30000);
           this.slow(10000);

--- a/test/grunt.js
+++ b/test/grunt.js
@@ -102,7 +102,7 @@ describe('grunt-google-closure-compiler', function() {
     originalCompilerRunMethod = Object.getOwnPropertyDescriptor(ClosureCompiler.prototype, 'run');
     Object.defineProperty(ClosureCompiler.prototype, 'run', {
       value: function(...args) {
-        const retVal = originalCompilerRunMethod.value.apply(this, ...args);
+        const retVal = originalCompilerRunMethod.value.apply(this, args);
         platformUtilized = /^java/.test(this.getFullCommand()) ? 'java' : 'native';
         return retVal;
       },
@@ -115,7 +115,7 @@ describe('grunt-google-closure-compiler', function() {
     Object.defineProperty(JsClosureCompiler.prototype, 'run', {
       value: function(...args) {
         platformUtilized = 'javascript';
-        return originalJsCompilerRunMethod.value.apply(this, ...args);
+        return originalJsCompilerRunMethod.value.apply(this, args);
       },
       writable: true,
       enumerable: false,
@@ -221,6 +221,7 @@ describe('grunt-google-closure-compiler', function() {
         }
 
         mockGrunt.fail.warn = (err, code) => {
+          console.error(err);
           assertNoError.fail();
           taskDone();
         };

--- a/test/gulp.js
+++ b/test/gulp.js
@@ -186,34 +186,36 @@ describe('gulp-google-closure-compiler', function() {
         stream.end();
       });
 
-      it('should compile multiple inputs into multiple outputs with chunk options', done => {
-        const stream = closureCompiler({
-          compilation_level: 'SIMPLE',
-          warning_level: 'VERBOSE',
-          chunk: [
-            'one:1',
-            'two:1'
-          ],
-          createSourceMap: true
-        }, {
-          platform
+      if (platform !== 'javascript') {
+        it('should compile multiple inputs into multiple outputs with chunk options', done => {
+          const stream = closureCompiler({
+            compilation_level: 'SIMPLE',
+            warning_level: 'VERBOSE',
+            chunk: [
+              'one:1',
+              'two:1'
+            ],
+            createSourceMap: true
+          }, {
+            platform
+          });
+
+          stream.pipe(assert.length(2))
+                .pipe(assert.first(f => {
+                  f.contents.toString().trim().should.eql(fakeFile1.contents.toString());
+                  f.path.should.eql('one.js');
+                }))
+                .pipe(assert.second(f => {
+                  f.contents.toString().trim().should.eql(fakeFile2.contents.toString());
+                  f.path.should.eql('two.js');
+                }))
+                .pipe(assert.end(done));
+
+          stream.write(fakeFile1);
+          stream.write(fakeFile2);
+          stream.end();
         });
-
-        stream.pipe(assert.length(2))
-          .pipe(assert.first(f => {
-            f.contents.toString().trim().should.eql(fakeFile1.contents.toString());
-            f.path.should.eql('one.js');
-          }))
-          .pipe(assert.second(f => {
-            f.contents.toString().trim().should.eql(fakeFile2.contents.toString());
-            f.path.should.eql('two.js');
-          }))
-          .pipe(assert.end(done));
-
-        stream.write(fakeFile1);
-        stream.write(fakeFile2);
-        stream.end();
-      });
+      }
 
       it('should generate a sourcemap for a single output file', done => {
         gulp.src('test/fixtures/**/*.js', {base: './'})
@@ -232,32 +234,34 @@ describe('gulp-google-closure-compiler', function() {
           .pipe(assert.end(done));
       });
 
-      it('should generate a sourcemap for each output file with chunks', done => {
-        gulp.src(__dirname + '/fixtures/**/*.js')
-          .pipe(sourcemaps.init())
-          .pipe(closureCompiler({
-            compilation_level: 'SIMPLE',
-            warning_level: 'VERBOSE',
-            chunk: [
-              'one:1',
-              'two:1:one'
-            ],
-            createSourceMap: true
-          }, {
-            debugLog: true,
-            platform
-          }))
-          .pipe(assert.length(2))
-          .pipe(assert.first(f => {
-            f.sourceMap.sources.should.have.length(1);
-            f.sourceMap.file.should.eql('./one.js');
-          }))
-          .pipe(assert.second(f => {
-            f.sourceMap.sources.should.have.length(1);
-            f.sourceMap.file.should.eql('./two.js');
-          }))
-          .pipe(assert.end(done));
-      });
+      if (platform !== 'javascript') {
+        it('should generate a sourcemap for each output file with chunks', done => {
+          gulp.src(__dirname + '/fixtures/**/*.js')
+              .pipe(sourcemaps.init())
+              .pipe(closureCompiler({
+                compilation_level: 'SIMPLE',
+                warning_level: 'VERBOSE',
+                chunk: [
+                  'one:1',
+                  'two:1:one'
+                ],
+                createSourceMap: true
+              }, {
+                debugLog: true,
+                platform
+              }))
+              .pipe(assert.length(2))
+              .pipe(assert.first(f => {
+                f.sourceMap.sources.should.have.length(1);
+                f.sourceMap.file.should.eql('./one.js');
+              }))
+              .pipe(assert.second(f => {
+                f.sourceMap.sources.should.have.length(1);
+                f.sourceMap.file.should.eql('./two.js');
+              }))
+              .pipe(assert.end(done));
+        });
+      }
 
       if (platform !== 'javascript') {
         it('should support passing input globs directly to the compiler', done => {

--- a/test/gulp.js
+++ b/test/gulp.js
@@ -35,7 +35,7 @@ process.on('unhandledRejection', e => { throw e; });
 describe('gulp-google-closure-compiler', function() {
   ['java', 'native', 'javascript'].forEach(platform => {
     describe(`${platform} version`, function() {
-      const closureCompiler = compilerPackage.gulp({platform});
+      const closureCompiler = compilerPackage.gulp();
       this.timeout(30000);
       this.slow(10000);
 
@@ -56,6 +56,8 @@ describe('gulp-google-closure-compiler', function() {
       it('should emit an error for invalid options', done => {
         const stream = closureCompiler({
           compilation_level: 'FOO'
+        }, {
+          platform
         });
 
         stream.on('error', err => {
@@ -70,6 +72,8 @@ describe('gulp-google-closure-compiler', function() {
         const stream = closureCompiler({
           compilation_level: 'SIMPLE',
           warning_level: 'VERBOSE'
+        }, {
+          platform
         });
 
         stream.pipe(assert.length(1))
@@ -86,6 +90,8 @@ describe('gulp-google-closure-compiler', function() {
         const stream = closureCompiler({
           compilation_level: 'SIMPLE',
           warning_level: 'VERBOSE'
+        }, {
+          platform
         });
         stream.pipe(assert.length(1))
           .pipe(assert.first(f => {
@@ -102,6 +108,8 @@ describe('gulp-google-closure-compiler', function() {
           compilation_level: 'SIMPLE',
           warning_level: 'VERBOSE',
           js_output_file: 'out.js'
+        }, {
+          platform
         });
         stream.pipe(assert.length(1))
           .pipe(assert.first(f => {
@@ -117,6 +125,8 @@ describe('gulp-google-closure-compiler', function() {
         const stream = closureCompiler({
           compilation_level: 'SIMPLE',
           warning_level: 'VERBOSE'
+        }, {
+          platform
         });
 
         stream.pipe(assert.length(1))
@@ -140,6 +150,8 @@ describe('gulp-google-closure-compiler', function() {
             'two:1'
           ],
           createSourceMap: true
+        }, {
+          platform
         });
 
         stream.pipe(assert.length(2))
@@ -164,6 +176,8 @@ describe('gulp-google-closure-compiler', function() {
           .pipe(closureCompiler({
             compilation_level: 'SIMPLE',
             warning_level: 'VERBOSE'
+          }, {
+            platform
           }))
           .pipe(assert.length(1))
           .pipe(assert.first(f => {
@@ -184,7 +198,10 @@ describe('gulp-google-closure-compiler', function() {
               'two:1:one'
             ],
             createSourceMap: true
-          }, {debugLog: true}))
+          }, {
+            debugLog: true,
+            platform
+          }))
           .pipe(assert.length(2))
           .pipe(assert.first(f => {
             f.sourceMap.sources.should.have.length(1);
@@ -203,6 +220,8 @@ describe('gulp-google-closure-compiler', function() {
             js: __dirname + '/fixtures/**.js',
             compilation_level: 'SIMPLE',
             warning_level: 'VERBOSE'
+          }, {
+            platform
           })
             .src()
             .pipe(assert.length(1))
@@ -218,6 +237,8 @@ describe('gulp-google-closure-compiler', function() {
               js: __dirname + '/fixtures/one.js',
               compilation_level: 'SIMPLE',
               warning_level: 'VERBOSE'
+            }, {
+              platform
             }))
             .pipe(assert.length(1))
             .pipe(assert.first(f => {
@@ -231,7 +252,9 @@ describe('gulp-google-closure-compiler', function() {
             '--js="' + __dirname + '/fixtures/**.js"',
             '--compilation_level=SIMPLE',
             '--warning_level=VERBOSE'
-          ])
+          ], {
+            platform
+          })
             .src()
             .pipe(assert.length(1))
             .pipe(assert.first(f => {
@@ -245,6 +268,8 @@ describe('gulp-google-closure-compiler', function() {
             compilation_level: 'SIMPLE',
             warning_level: 'VERBOSE',
             js: __dirname + '/fixtures/**.js'
+          }, {
+            platform
           })
             .src()
             .pipe(assert.length(1))
@@ -260,6 +285,8 @@ describe('gulp-google-closure-compiler', function() {
           .pipe(closureCompiler({
             compilation_level: 'SIMPLE',
             warning_level: 'VERBOSE'
+          }, {
+            platform
           }))
           .pipe(assert.length(0))
           .pipe(assert.end(done));
@@ -273,6 +300,8 @@ describe('gulp-google-closure-compiler', function() {
             warning_level: 'VERBOSE',
             formatting: 'PRETTY_PRINT',
             sourceMapIncludeContent: true
+          }, {
+            platform
           }))
           .pipe(closureCompiler({
             compilation_level: 'SIMPLE',
@@ -296,6 +325,8 @@ describe('gulp-google-closure-compiler', function() {
           .pipe(closureCompiler({
             compilation_level: 'SIMPLE',
             warning_level: 'VERBOSE'
+          }, {
+            platform
           }))
           .on('error', err => {
             err.message.should.eql('Streaming not supported');

--- a/test/gulp.js
+++ b/test/gulp.js
@@ -44,7 +44,7 @@ describe('gulp-google-closure-compiler', function() {
     originalCompilerRunMethod = Object.getOwnPropertyDescriptor(ClosureCompiler.prototype, 'run');
     Object.defineProperty(ClosureCompiler.prototype, 'run', {
       value: function(...args) {
-        const retVal = originalCompilerRunMethod.value.apply(this, ...args);
+        const retVal = originalCompilerRunMethod.value.apply(this, args);
         platformUtilized = /^java/.test(this.getFullCommand()) ? 'java' : 'native';
         return retVal;
       },
@@ -57,7 +57,7 @@ describe('gulp-google-closure-compiler', function() {
     Object.defineProperty(JsClosureCompiler.prototype, 'run', {
       value: function(...args) {
         platformUtilized = 'javascript';
-        return originalJsCompilerRunMethod.value.apply(this, ...args);
+        return originalJsCompilerRunMethod.value.apply(this, args);
       },
       writable: true,
       enumerable: false,

--- a/test/gulp.js
+++ b/test/gulp.js
@@ -23,6 +23,7 @@
 'use strict';
 
 const assert = require('stream-assert');
+const should = require('should');
 const gulp = require('gulp');
 const sourcemaps = require('gulp-sourcemaps');
 const File = require('vinyl');
@@ -32,9 +33,9 @@ require('mocha');
 process.on('unhandledRejection', e => { throw e; });
 
 describe('gulp-google-closure-compiler', function() {
-  ['java', 'javascript'].forEach(mode => {
-    describe(`${mode} version`, function() {
-      const closureCompiler = compilerPackage.gulp({jsMode: mode === 'javascript'});
+  ['java', 'native', 'javascript'].forEach(platform => {
+    describe(`${platform} version`, function() {
+      const closureCompiler = compilerPackage.gulp({platform});
       this.timeout(30000);
       this.slow(10000);
 
@@ -72,10 +73,10 @@ describe('gulp-google-closure-compiler', function() {
         });
 
         stream.pipe(assert.length(1))
-        .pipe(assert.first(f => {
-          f.contents.toString().trim().should.eql(fakeFile1.contents.toString());
-        }))
-        .pipe(assert.end(done));
+          .pipe(assert.first(f => {
+            f.contents.toString().trim().should.eql(fakeFile1.contents.toString());
+          }))
+          .pipe(assert.end(done));
 
         stream.write(fakeFile1);
         stream.end();
@@ -87,10 +88,10 @@ describe('gulp-google-closure-compiler', function() {
           warning_level: 'VERBOSE'
         });
         stream.pipe(assert.length(1))
-        .pipe(assert.first(f => {
-          f.path.should.eql('compiled.js');
-        }))
-        .pipe(assert.end(done));
+          .pipe(assert.first(f => {
+            f.path.should.eql('compiled.js');
+          }))
+          .pipe(assert.end(done));
 
         stream.write(fakeFile1);
         stream.end();
@@ -103,10 +104,10 @@ describe('gulp-google-closure-compiler', function() {
           js_output_file: 'out.js'
         });
         stream.pipe(assert.length(1))
-        .pipe(assert.first(f => {
-          f.path.should.eql('out.js');
-        }))
-        .pipe(assert.end(done));
+          .pipe(assert.first(f => {
+            f.path.should.eql('out.js');
+          }))
+          .pipe(assert.end(done));
 
         stream.write(fakeFile1);
         stream.end();
@@ -119,29 +120,29 @@ describe('gulp-google-closure-compiler', function() {
         });
 
         stream.pipe(assert.length(1))
-        .pipe(assert.first(f => {
-          f.contents.toString().trim().should.eql(fakeFile1.contents.toString() +
-              fakeFile2.contents.toString());
-        }))
-        .pipe(assert.end(done));
+          .pipe(assert.first(f => {
+            f.contents.toString().trim().should.eql(fakeFile1.contents.toString() +
+                fakeFile2.contents.toString());
+          }))
+          .pipe(assert.end(done));
 
         stream.write(fakeFile1);
         stream.write(fakeFile2);
         stream.end();
       });
 
-      if (mode !== 'javascript') {
-        it('should compile multiple inputs into multiple outputs with module options', done => {
-          const stream = closureCompiler({
-            compilation_level: 'SIMPLE',
-            warning_level: 'VERBOSE',
-            module: [
-              'one:1',
-              'two:1'
-            ]
-          });
+      it('should compile multiple inputs into multiple outputs with chunk options', done => {
+        const stream = closureCompiler({
+          compilation_level: 'SIMPLE',
+          warning_level: 'VERBOSE',
+          chunk: [
+            'one:1',
+            'two:1'
+          ],
+          createSourceMap: true
+        });
 
-          stream.pipe(assert.length(2))
+        stream.pipe(assert.length(2))
           .pipe(assert.first(f => {
             f.contents.toString().trim().should.eql(fakeFile1.contents.toString());
             f.path.should.eql('one.js');
@@ -152,39 +153,38 @@ describe('gulp-google-closure-compiler', function() {
           }))
           .pipe(assert.end(done));
 
-          stream.write(fakeFile1);
-          stream.write(fakeFile2);
-          stream.end();
-        });
-      }
+        stream.write(fakeFile1);
+        stream.write(fakeFile2);
+        stream.end();
+      });
 
       it('should generate a sourcemap for a single output file', done => {
         gulp.src('test/fixtures/**/*.js', {base: './'})
-        .pipe(sourcemaps.init())
-        .pipe(closureCompiler({
-          compilation_level: 'SIMPLE',
-          warning_level: 'VERBOSE'
-        }))
-        .pipe(assert.length(1))
-        .pipe(assert.first(f => {
-          f.sourceMap.sources.should.have.length(2);
-          f.sourceMap.file.should.eql('compiled.js');
-        }))
-        .pipe(assert.end(done));
+          .pipe(sourcemaps.init())
+          .pipe(closureCompiler({
+            compilation_level: 'SIMPLE',
+            warning_level: 'VERBOSE'
+          }))
+          .pipe(assert.length(1))
+          .pipe(assert.first(f => {
+            f.sourceMap.sources.should.have.length(2);
+            f.sourceMap.file.should.eql('compiled.js');
+          }))
+          .pipe(assert.end(done));
       });
 
-      if (mode !== 'javascript') {
-        it('should generate a sourcemap for each output file with modules', done => {
-          gulp.src(__dirname + '/fixtures/**/*.js')
+      it('should generate a sourcemap for each output file with chunks', done => {
+        gulp.src(__dirname + '/fixtures/**/*.js')
           .pipe(sourcemaps.init())
           .pipe(closureCompiler({
             compilation_level: 'SIMPLE',
             warning_level: 'VERBOSE',
-            module: [
+            chunk: [
               'one:1',
               'two:1:one'
-            ]
-          }))
+            ],
+            createSourceMap: true
+          }, {debugLog: true}))
           .pipe(assert.length(2))
           .pipe(assert.first(f => {
             f.sourceMap.sources.should.have.length(1);
@@ -195,34 +195,35 @@ describe('gulp-google-closure-compiler', function() {
             f.sourceMap.file.should.eql('./two.js');
           }))
           .pipe(assert.end(done));
-        });
+      });
 
+      if (platform !== 'javascript') {
         it('should support passing input globs directly to the compiler', done => {
           const stream = closureCompiler({
             js: __dirname + '/fixtures/**.js',
             compilation_level: 'SIMPLE',
             warning_level: 'VERBOSE'
           })
-          .src()
-          .pipe(assert.length(1))
-          .pipe(assert.first(f => {
-            f.contents.toString().should.eql(fixturesCompiled);
-          }))
-          .pipe(assert.end(done));
+            .src()
+            .pipe(assert.length(1))
+            .pipe(assert.first(f => {
+              f.contents.toString().should.eql(fixturesCompiled);
+            }))
+            .pipe(assert.end(done));
         });
 
         it('should include js options before gulp.src files', done => {
           gulp.src(__dirname + '/fixtures/two.js')
-          .pipe(closureCompiler({
-            js: __dirname + '/fixtures/one.js',
-            compilation_level: 'SIMPLE',
-            warning_level: 'VERBOSE'
-          }))
-          .pipe(assert.length(1))
-          .pipe(assert.first(f => {
-            f.contents.toString().should.eql(fixturesCompiled);
-          }))
-          .pipe(assert.end(done));
+            .pipe(closureCompiler({
+              js: __dirname + '/fixtures/one.js',
+              compilation_level: 'SIMPLE',
+              warning_level: 'VERBOSE'
+            }))
+            .pipe(assert.length(1))
+            .pipe(assert.first(f => {
+              f.contents.toString().should.eql(fixturesCompiled);
+            }))
+            .pipe(assert.end(done));
         });
 
         it('should support calling the compiler with an arguments array', done => {
@@ -231,12 +232,12 @@ describe('gulp-google-closure-compiler', function() {
             '--compilation_level=SIMPLE',
             '--warning_level=VERBOSE'
           ])
-          .src()
-          .pipe(assert.length(1))
-          .pipe(assert.first(f => {
-            f.contents.toString().should.eql(fixturesCompiled);
-          }))
-          .pipe(assert.end(done));
+            .src()
+            .pipe(assert.length(1))
+            .pipe(assert.first(f => {
+              f.contents.toString().should.eql(fixturesCompiled);
+            }))
+            .pipe(assert.end(done));
         });
 
         it('should compile without gulp.src files when .src() is called', done => {
@@ -245,23 +246,23 @@ describe('gulp-google-closure-compiler', function() {
             warning_level: 'VERBOSE',
             js: __dirname + '/fixtures/**.js'
           })
-          .src()
-          .pipe(assert.length(1))
-          .pipe(assert.first(f => {
-            f.contents.toString().should.eql(fixturesCompiled);
-          }))
-          .pipe(assert.end(done));
+            .src()
+            .pipe(assert.length(1))
+            .pipe(assert.first(f => {
+              f.contents.toString().should.eql(fixturesCompiled);
+            }))
+            .pipe(assert.end(done));
         });
       }
 
       it('should generate no output without gulp.src files', done => {
         gulp.src([])
-        .pipe(closureCompiler({
-          compilation_level: 'SIMPLE',
-          warning_level: 'VERBOSE'
-        }))
-        .pipe(assert.length(0))
-        .pipe(assert.end(done));
+          .pipe(closureCompiler({
+            compilation_level: 'SIMPLE',
+            warning_level: 'VERBOSE'
+          }))
+          .pipe(assert.length(0))
+          .pipe(assert.end(done));
       });
 
       it('should properly compose sourcemaps when multiple transformations are chained', done => {
@@ -292,14 +293,14 @@ describe('gulp-google-closure-compiler', function() {
 
       it('in streaming mode should emit an error', done => {
         gulp.src(__dirname + '/fixtures/**/*.js', {buffer: false})
-        .pipe(closureCompiler({
-          compilation_level: 'SIMPLE',
-          warning_level: 'VERBOSE'
-        }))
-        .on('error', err => {
-          err.message.should.eql('Streaming not supported');
-          done();
-        });
+          .pipe(closureCompiler({
+            compilation_level: 'SIMPLE',
+            warning_level: 'VERBOSE'
+          }))
+          .on('error', err => {
+            err.message.should.eql('Streaming not supported');
+            done();
+          });
       });
     });
   });

--- a/test/node.js
+++ b/test/node.js
@@ -64,7 +64,7 @@ describe('closure-compiler node bindings', () => {
         three: ['one', 'two', 'three']
       });
 
-      const expectedArray = ['-jar', Compiler.COMPILER_PATH, '--one=true', '--two=two',
+      const expectedArray = ['--one=true', '--two=two',
         '--three=one', '--three=two', '--three=three'];
       compiler.commandArguments.length.should.eql(expectedArray.length);
       compiler.commandArguments.forEach((item, index) => {
@@ -72,40 +72,49 @@ describe('closure-compiler node bindings', () => {
       });
     });
 
-    it('should prepend the -jar argument and compiler path when configured by array', () => {
+    it('should prepend the -jar argument and compiler path when configured by array', done => {
       const expectedArray = ['-jar', Compiler.COMPILER_PATH, '--one=true', '--two=two',
         '--three=one', '--three=two', '--three=three'];
 
       const compiler = new Compiler(expectedArray.slice(2));
 
-      compiler.commandArguments.length.should.eql(expectedArray.length);
-      compiler.commandArguments.forEach((item, index) => {
-        expectedArray[index].should.eql(item);
+      compiler.run(() => {
+        compiler.commandArguments.length.should.eql(expectedArray.length);
+        compiler.commandArguments.forEach((item, index) => {
+          expectedArray[index].should.eql(item);
+        });
+        done();
       });
     });
 
-    describe('extra command arguments', () => {
-      it('should include initial command arguments when configured by an options object', () => {
+    describe('extra command arguments', done => {
+      it('should include initial command arguments when configured by an options object', done => {
         const expectedArray = ['-Xms2048m', '-jar', Compiler.COMPILER_PATH, '--one=true', '--two=two',
           '--three=one', '--three=two', '--three=three'];
 
         const compiler = new Compiler(expectedArray.slice(3), expectedArray.slice(0, 1));
 
-        compiler.commandArguments.length.should.eql(expectedArray.length);
-        compiler.commandArguments.forEach(function (item, index) {
-          expectedArray[index].should.eql(item);
+        compiler.run(() => {
+          compiler.commandArguments.length.should.eql(expectedArray.length);
+          compiler.commandArguments.forEach(function (item, index) {
+            expectedArray[index].should.eql(item);
+          });
+          done();
         });
       });
 
-      it('should include initial command arguments when configured by array', () => {
+      it('should include initial command arguments when configured by array', done => {
         const expectedArray = ['-Xms2048m', '-jar', Compiler.COMPILER_PATH, '--one=true', '--two=two',
           '--three=one', '--three=two', '--three=three'];
 
         const compiler = new Compiler(expectedArray.slice(3), expectedArray.slice(0, 1));
 
-        compiler.commandArguments.length.should.eql(expectedArray.length);
-        compiler.commandArguments.forEach(function (item, index) {
-          expectedArray[index].should.eql(item);
+        compiler.run(() => {
+          compiler.commandArguments.length.should.eql(expectedArray.length);
+          compiler.commandArguments.forEach(function (item, index) {
+            expectedArray[index].should.eql(item);
+          });
+          done();
         });
       });
     });

--- a/version-match.js
+++ b/version-match.js
@@ -1,0 +1,1 @@
+module.exports = /^Version: v(\d+)(?:[-\.][-a-z0-9]+)*$/m;

--- a/yarn.lock
+++ b/yarn.lock
@@ -558,6 +558,14 @@ glogg@^1.0.0:
   dependencies:
     sparkles "^1.0.0"
 
+google-closure-compiler-linux@^20180610.0.1:
+  version "20180610.0.1"
+  resolved "https://registry.yarnpkg.com/google-closure-compiler-linux/-/google-closure-compiler-linux-20180610.0.1.tgz#cc69d89beebb2a629eae6a76c7672790f5bd7a02"
+
+google-closure-compiler-osx@^20180610.0.1:
+  version "20180610.0.1"
+  resolved "https://registry.yarnpkg.com/google-closure-compiler-osx/-/google-closure-compiler-osx-20180610.0.1.tgz#968e17f481daf87355de3ea04ab7429a58b1413f"
+
 graceful-fs@4.X:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"


### PR DESCRIPTION
Adds the new graal native packages as optional dependencies. They will be installed if their OS and architecture restrictions are met.

Updates the grunt and gulp plugins to support a `platform` flag to switch between each version of the compiler. The flag may be an array in preference order where the first supported platform will be used.

If the java platform is not the last platform listed, support for java will be detected by the presence of the `JAVA_HOME` environment variable.

Currently, `java` remains the default platform but the native versions may become default when available by a future release.