### PR TITLE
Move gulp back to a dependency as it is required for grunt

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,10 +43,10 @@
   "dependencies": {
     "chalk": "^1.0.0",
     "vinyl": "^2.0.1",
-    "vinyl-sourcemaps-apply": "^0.2.0"
+    "vinyl-sourcemaps-apply": "^0.2.0",
+    "gulp": "^3.9.0"
   },
   "devDependencies": {
-    "gulp": "^3.9.0",
     "gulp-mocha": "6.0.0",
     "gulp-sourcemaps": "^2.6.4",
     "lodash": "^4.17.10",


### PR DESCRIPTION
Gulp is directly required by the grunt plugin currently. We should probably change that at some point. But for now gulp needs to be a dependency of the project.