### PR TITLE
Remove gulp as a direct dependency of the grunt plugin

### DIFF
--- a/lib/grunt/index.js
+++ b/lib/grunt/index.js
@@ -31,7 +31,6 @@ module.exports = (grunt, pluginOptions) => {
   const VinylStream = require('./vinyl-stream');
   const Transform = require('stream').Transform;
   const gulpCompilerOptions = {};
-  const gulp = require('gulp');
   const {getFirstSupportedPlatform} = require('../utils');
 
   let extraArguments;
@@ -55,6 +54,18 @@ module.exports = (grunt, pluginOptions) => {
     platforms = ['native', 'java', 'javascript'];
   }
   const platform = getFirstSupportedPlatform(platforms);
+
+  class WriteGruntFiles extends Transform {
+    constructor() {
+      super({objectMode: true});
+    }
+
+    _transform(file, enc, cb) {
+      grunt.file.write(file.path, file.contents);
+      this.push(file);
+      cb();
+    }
+  }
 
   /**
    * @param {Array<string>}|null} files
@@ -113,7 +124,7 @@ module.exports = (grunt, pluginOptions) => {
           stream = stream.on('error', err => {
             hadError = true;
             reject(err);
-          }).pipe(gulp.dest(""));
+          }).pipe(new WriteGruntFiles());
         }
       } else {
         // No source files were provided. Assume the options specify
@@ -124,7 +135,7 @@ module.exports = (grunt, pluginOptions) => {
           stream = stream.on('error', err => {
             hadError = true;
             reject(err);
-          }).pipe(gulp.dest(""));
+          }).pipe(new WriteGruntFiles());
         }
         stream.end();
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "google-closure-compiler",
-  "version": "20180716.0.0",
+  "version": "20180716.0.1",
   "description": "Check, compile, optimize and compress Javascript with Closure-Compiler",
   "repository": {
     "type": "git",
@@ -42,7 +42,6 @@
   "homepage": "https://developers.google.com/closure/compiler/",
   "dependencies": {
     "chalk": "^1.0.0",
-    "gulp": "^3.9.0",
     "vinyl": "^2.0.1",
     "vinyl-sourcemaps-apply": "^0.2.0"
   },
@@ -51,6 +50,7 @@
     "google-closure-compiler-osx": "^20180716.0.0"
   },
   "devDependencies": {
+    "gulp": "^3.9.0",
     "gulp-mocha": "6.0.0",
     "gulp-sourcemaps": "^2.6.4",
     "lodash": "^4.17.10",

--- a/test/grunt.js
+++ b/test/grunt.js
@@ -24,6 +24,7 @@
 
 const should = require('should');
 const fs = require('fs');
+const path = require('path');
 const _ = require('lodash');
 const ClosureCompiler = require('../lib/node/closure-compiler');
 const JsClosureCompiler = require('../lib/node/closure-compiler-js');
@@ -64,10 +65,22 @@ const mockGrunt = {
       } catch (e) {
         return false;
       }
+    },
+    write: function(filepath, contents, opts) {
+      const pathSegments = filepath.split(path.sep);
+      for (let i = 0; i < pathSegments.length - 1; i++) {
+        const intermediatePath = pathSegments.slice(0, i + 1).join(path.sep);
+        try {
+          fs.mkdirSync(intermediatePath);
+        } catch (e) {}
+      }
+      return fs.writeFileSync(filepath, contents, opts);
     }
   },
   fail: {
-    warn: function() {}
+    warn: function(...args) {
+      console.error(args);
+    }
   },
   registerMultiTask: function() {}
 };


### PR DESCRIPTION
Gulp dependencies have security vulnerabilities so we need to not directly depend on them