### PR TITLE
Cache the maven directory for faster travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: node_js
 node_js:
 - '8'
 - '6'
+cache:
+  directories:
+  - $HOME/.m2
 branches:
   only:
   - master


### PR DESCRIPTION
Avoids downloading all the gwt build dependencies independently on every build