### PR TITLE
Move over and use the cli logger from the closure-compiler-js repo

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -123,17 +123,17 @@ if (platform !== 'javascript') {
     })
     .then(inputFiles => {
       const Compiler = require('./lib/node/closure-compiler-js');
+      const logErrors = require('./lib/logger');
       const compiler = new Compiler(compilerFlags);
-      compiler.run(inputFiles, (exitCode, compiledFiles, errors) => {
-        if (errors && errors.length > 0) {
-          console.error(errors);
-        }
-        if (compiledFiles.length === 1 && compiledFiles[0].path === 'compiled.js' && !compilerFlags['js_output_file']) {
-          console.log(compiledFiles[0].src);
-        }
+      const output = compiler.run(inputFiles);
+      const exitCode = output.errors.length === 0 ? 0 : 1;
+      logErrors(output, inputFiles);
+      if (output.compiledFiles.length === 1 && output.compiledFiles[0].path === 'compiled.js' &&
+          !compilerFlags['js_output_file']) {
+        console.log(output.compiledFiles[0].src);
+      }
 
-        process.exitCode = process.exitCode || exitCode;
-      });
+      process.exitCode = process.exitCode || exitCode;
     })
     .catch(e => {
       console.error(e);

--- a/lib/gulp/index.js
+++ b/lib/gulp/index.js
@@ -144,20 +144,16 @@ module.exports = function(initOptions) {
       const Compiler = getCompiler(this.platform);
       const compiler = new Compiler(this.compilationOptions_, extraCommandArguments);
       if (this.platform === 'javascript') {
-        let compilerProcess;
         try {
-          compilerProcess = compiler.run(jsonFiles);
+          compiler.run(jsonFiles, (exitCode, outputFiles, errors) => {
+            this._compilationComplete(exitCode, outputFiles, errors);
+            cb();
+          });
         } catch (e) {
           this._compilationComplete(1, [], e.message.replace(/^java.lang.RuntimeException: /, ''));
           cb();
           return;
         }
-        const errors = [].slice.call(compilerProcess.warnings).concat([].slice.call(compilerProcess.errors));
-        this._compilationComplete(
-            compilerProcess.errors.length === 0 ? 0 : 1,
-            compilerProcess.compiledFiles,
-            errors.join('\n\n'));
-        cb();
       } else {
         if (this.platform === 'native') {
           compiler.JAR_PATH = null;

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2016 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Logger for Closure Compiler JS output.
+ */
+
+'use strict';
+
+const ESC = '\u001B';
+const COLOR_END = ESC + '[0m';
+const COLOR_RED = ESC + '[91m';
+const COLOR_GREEN = ESC + '[92m';
+const COLOR_YELLOW = ESC + '[93m';
+const fs = require('fs');
+
+/**
+ * @param {string} line to generate prefix for
+ * @param {number} charNo to generate prefix at
+ * @return {string} prefix for showing a caret
+ */
+function caretPrefix(line, charNo) {
+  return line.substr(0, charNo).replace(/[^\t]/g, ' ');
+}
+
+
+/**
+ * @param {!Object} output
+ * @param {!Array<{src:string, path:string}>} inputFiles
+ * @param {function(string)} logger
+ * @return {boolean} Whether this output should fail a compilation.
+ */
+module.exports = function(output, inputFiles = [], logger = console.warn) {
+  // TODO(samthor): If this file has a sourceMap, then follow it back out of the rabbit hole.
+  function fileFor(file) {
+    if (!file) {
+      return null;
+    }
+
+    const originalFile = inputFiles.find(inputFile => inputFile.path === file);
+    if (originalFile) {
+      return originalFile;
+    }
+
+    try {
+      return {
+        path: file,
+        src: fs.readFileSync(file, 'utf8')
+      }
+    } catch (e) { }
+    return null;
+  }
+
+  function writemsg(color, msg) {
+    if (!msg.file && msg.lineNo < 0) {
+      logger(msg.type);
+    } else {
+      logger(`${msg.file}:${msg.lineNo} (${msg.type})`)
+    }
+    logger(msg.description);
+
+    const file = fileFor(msg.file);
+    if (file) {
+      const lines = file.src.split('\n');  // TODO(samthor): cache this for logger?
+      const line = lines[msg.lineNo - 1] || '';
+      logger(color + line + COLOR_END);
+      logger(COLOR_GREEN + caretPrefix(line, msg.charNo) + '^' + COLOR_END);
+    }
+    logger('');
+  }
+
+  output.warnings.forEach(writemsg.bind(null, COLOR_YELLOW));
+  output.errors.forEach(writemsg.bind(null, COLOR_RED));
+
+  return output.errors.length > 0;
+};

--- a/lib/node/closure-compiler-js.js
+++ b/lib/node/closure-compiler-js.js
@@ -25,6 +25,7 @@
 const path = require('path');
 const contribPath = path.dirname(path.resolve(__dirname, '../../')) + '/contrib';
 const jscomp = require('../../jscomp.js');
+const CONSOLE_COLOR_CHARS = /\u001B\[\d+m/ug;
 
 class CompilerJS {
   /** @param {Object<string,string>|Array<string>} flags */
@@ -51,13 +52,16 @@ class CompilerJS {
    */
   run(fileList, callback) {
     const out = jscomp(this.flags, fileList);
+    // GWT error and warnings are not true JS arrays, but are array-like.
+    // Convert them to standard JS arrays.
     out.warnings = [].slice.call(out.warnings);
     out.errors = [].slice.call(out.errors);
     if (callback) {
       const errors = [];
       const logErrors = require('../logger');
       logErrors(out, fileList, logOutput => {
-        errors.push(logOutput.replace(/\u001B\[\d+m/ug, ''));
+        // The logger uses terminal color markers which we don't want by default.
+        errors.push(logOutput.replace(CONSOLE_COLOR_CHARS, ''));
       });
       callback(errors.length === 0 ? 0 : 1, out.compiledFiles, errors.join('\n\n'));
     }

--- a/lib/node/closure-compiler-js.js
+++ b/lib/node/closure-compiler-js.js
@@ -46,15 +46,20 @@ class CompilerJS {
 
   /**
    * @param {!Array<!{src: string, path: string, sourceMap: string}>} fileList
-   * @param {function(number, string, string)=} callback
+   * @param {function(number, Array<{src: string, path: string, sourceMap: (string|undefined)}>, string)=} callback
    * @return {child_process.ChildProcess}
    */
   run(fileList, callback) {
     const out = jscomp(this.flags, fileList);
+    out.warnings = [].slice.call(out.warnings);
+    out.errors = [].slice.call(out.errors);
     if (callback) {
-      const warnings = Array.prototype.slice.call(out.warnings);
-      const errors = Array.prototype.slice.call(out.errors);
-      callback(errors.length === 0 ? 0 : 1, out.compiledFiles, out.warnings.concat(out.errors).join('\n\n'));
+      const errors = [];
+      const logErrors = require('../logger');
+      logErrors(out, fileList, logOutput => {
+        errors.push(logOutput.replace(/\u001B\[\d+m/ug, ''));
+      });
+      callback(errors.length === 0 ? 0 : 1, out.compiledFiles, errors.join('\n\n'));
     }
     return out;
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -57,6 +57,12 @@ function parseCliFlags(flags) {
       currentFlag = 'js';
     }
 
+    if (flagValue === 'true') {
+      flagValue = true;
+    } else if (flagValue === 'false') {
+      flagValue = false;
+    }
+
     if (compilerFlags[currentFlag] && !Array.isArray(compilerFlags[currentFlag])) {
       compilerFlags[currentFlag] = [compilerFlags[currentFlag], flagValue];
     } else {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -57,12 +57,6 @@ function parseCliFlags(flags) {
       currentFlag = 'js';
     }
 
-    if (flagValue === 'true') {
-      flagValue = true;
-    } else if (flagValue === 'false') {
-      flagValue = false;
-    }
-
     if (compilerFlags[currentFlag] && !Array.isArray(compilerFlags[currentFlag])) {
       compilerFlags[currentFlag] = [compilerFlags[currentFlag], flagValue];
     } else {

--- a/test/gulp.js
+++ b/test/gulp.js
@@ -201,15 +201,15 @@ describe('gulp-google-closure-compiler', function() {
           });
 
           stream.pipe(assert.length(2))
-                .pipe(assert.first(f => {
-                  f.contents.toString().trim().should.eql(fakeFile1.contents.toString());
-                  f.path.should.eql('one.js');
-                }))
-                .pipe(assert.second(f => {
-                  f.contents.toString().trim().should.eql(fakeFile2.contents.toString());
-                  f.path.should.eql('two.js');
-                }))
-                .pipe(assert.end(done));
+              .pipe(assert.first(f => {
+                f.contents.toString().trim().should.eql(fakeFile1.contents.toString());
+                f.path.should.eql('one.js');
+              }))
+              .pipe(assert.second(f => {
+                f.contents.toString().trim().should.eql(fakeFile2.contents.toString());
+                f.path.should.eql('two.js');
+              }))
+              .pipe(assert.end(done));
 
           stream.write(fakeFile1);
           stream.write(fakeFile2);


### PR DESCRIPTION
Cli logging for the JavaScript platform is broken. This moves the logger utility from the js repo over and uses it for the cli as well as the gulp plugin.