### PR TITLE
Properly handle boolean flag values for the cli parsing

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -38,77 +38,7 @@ function getFirstSupportedPlatform(platforms) {
   return platform;
 }
 
-/**
- * Parse cli provided flags and create an object
- *
- * @param {!Array<string>} flags
- * @return {!Object<string, (string|boolean|Array<string>)>}
- */
-function parseCliFlags(flags) {
-  const flagShortcuts = new Map([
-    ['-O', 'compilation_level'],
-    ['-W', 'warning_level']
-  ]);
-
-  const compilerFlags = {};
-  let currentFlag;
-  const addFlagValue = flagValue => {
-    if (!currentFlag) {
-      currentFlag = 'js';
-    }
-
-    if (flagValue === 'true') {
-      flagValue = true;
-    } else if (flagValue === 'false') {
-      flagValue = false;
-    }
-
-    if (compilerFlags[currentFlag] && !Array.isArray(compilerFlags[currentFlag])) {
-      compilerFlags[currentFlag] = [compilerFlags[currentFlag], flagValue];
-    } else {
-      compilerFlags[currentFlag] = flagValue;
-    }
-    currentFlag = undefined;
-  };
-  flags.forEach(flagOrValue => {
-    let nextFlag;
-    let maybeFlag = flagOrValue;
-    let eqIndex = flagOrValue.indexOf('=');
-    if (eqIndex > 0) {
-      maybeFlag = maybeFlag.substr(0, eqIndex);
-    }
-    if (flagShortcuts.has(maybeFlag)) {
-      nextFlag = flagShortcuts.get(maybeFlag);
-      if (eqIndex > 0) {
-        nextFlag += flagOrValue.substr(eqIndex);
-      }
-    } else if (/^--/.test(maybeFlag)) {
-      nextFlag = flagOrValue.substr(2);
-    } else {
-      addFlagValue(flagOrValue);
-    }
-    if (nextFlag) {
-      if (currentFlag) {
-        addFlagValue(true);
-      }
-
-      eqIndex = nextFlag.indexOf('=');
-      if (eqIndex > 0) {
-        currentFlag = nextFlag.substr(0, eqIndex);
-        addFlagValue(nextFlag.substr(eqIndex + 1));
-      } else {
-        currentFlag = nextFlag;
-      }
-    }
-  });
-  if (currentFlag) {
-    addFlagValue(true);
-  }
-  return compilerFlags;
-}
-
 module.exports = {
   getNativeImagePath,
-  getFirstSupportedPlatform,
-  parseCliFlags
+  getFirstSupportedPlatform
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -57,6 +57,12 @@ function parseCliFlags(flags) {
       currentFlag = 'js';
     }
 
+    if (flagValue === 'true') {
+      flagValue = true;
+    } else if (flagValue === 'false') {
+      flagValue = false;
+    }
+
     if (compilerFlags[currentFlag] && !Array.isArray(compilerFlags[currentFlag])) {
       compilerFlags[currentFlag] = [compilerFlags[currentFlag], flagValue];
     } else {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "homepage": "https://developers.google.com/closure/compiler/",
   "dependencies": {
     "chalk": "^1.0.0",
+    "minimist": "^1.2.0",
     "vinyl": "^2.0.1",
     "vinyl-sourcemaps-apply": "^0.2.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1163,7 +1163,7 @@ minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-minimist@^1.1.0:
+minimist@^1.1.0, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 


### PR DESCRIPTION
Currently you are unable to specify `--create_source_map=false` for the javascript platform. Special case "true" and "false" values.