### PR TITLE
Fail the build script if curl receives a non-success HTTP status code

### DIFF
--- a/build_compiler.js
+++ b/build_compiler.js
@@ -35,7 +35,7 @@ if (compilerJarStats && compilerJarStats.isFile()) {
 }
 
 if (shouldDownloadCompiler) {
-   const compilerBuild = spawnSync('curl', ['-s', '-S', '-L', '-o', './compiler.jar', url], {
+   const compilerBuild = spawnSync('curl', ['--fail', '-s', '-S', '-L', '-o', './compiler.jar', url], {
     stdio: 'inherit'
    });
 

--- a/deployments.md
+++ b/deployments.md
@@ -1,6 +1,7 @@
 # Deploying Closure Compiler to NPM
 
 *You now need yarn installed - `npm install -g yarn`*
+*The compiler must be published to maven first as the build script downloads the jar from maven.*
 
  1. Update the package version number in `package.json` at
     https://github.com/chadkillingsworth/closure-compiler-graal.


### PR DESCRIPTION
Without the `--fail` flag, curl has an exit code of 0 even if it receives an HTTP Status code that indicates an error.