### PR TITLE
Simplify the cli script now that the GWT version has filesystem support

### DIFF
--- a/test/cli.js
+++ b/test/cli.js
@@ -141,6 +141,39 @@ describe('command line interface', function() {
           .then(complete)
           .catch(complete);
       });
+
+      it('read input js files', done => {
+        function complete() {
+          should(exitCode).equal(0);
+          should(stdOut.length).above(0);
+          should(stdOut.indexOf('console.log')).above(-1);
+          done();
+        }
+
+        runCmd(cliPath, [`--platform=${platform}`, '--js=test/fixtures/one.js'])
+          .then(complete)
+          .catch(complete);
+      });
+
+      it('read extern files', done => {
+        function complete() {
+          should(exitCode).equal(0);
+          should(stdOut.length).above(0);
+          should(stdOut.indexOf('externalMethod')).above(-1);
+          done();
+        }
+
+        runCmd(
+            cliPath,
+            [
+              `--platform=${platform}`,
+              '--warning_level=VERBOSE',
+              '--externs=test/fixtures/extern.js'
+            ],
+            'externalMethod("foo")')
+          .then(complete)
+          .catch(complete);
+      });
     });
   });
 });

--- a/test/cli.js
+++ b/test/cli.js
@@ -151,8 +151,7 @@ describe('command line interface', function() {
         }
 
         runCmd(cliPath, [`--platform=${platform}`, '--js=test/fixtures/one.js'])
-          .then(complete)
-          .catch(complete);
+          .then(complete, complete);
       });
 
       it('read extern files', done => {
@@ -171,8 +170,7 @@ describe('command line interface', function() {
               '--externs=test/fixtures/extern.js'
             ],
             'externalMethod("foo")')
-          .then(complete)
-          .catch(complete);
+          .then(complete, complete);
       });
     });
   });

--- a/test/fixtures/extern.js
+++ b/test/fixtures/extern.js
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview
+ * @externs
+ */
+
+/** @param {string} input */
+function externalMethod(input) {}

--- a/test/gulp.js
+++ b/test/gulp.js
@@ -236,7 +236,7 @@ describe('gulp-google-closure-compiler', function() {
 
       if (platform !== 'javascript') {
         it('should generate a sourcemap for each output file with chunks', done => {
-          gulp.src(__dirname + '/fixtures/**/*.js')
+          gulp.src([__dirname + '/fixtures/one.js', __dirname + '/fixtures/two.js'])
               .pipe(sourcemaps.init())
               .pipe(closureCompiler({
                 compilation_level: 'SIMPLE',


### PR DESCRIPTION
Now that https://github.com/google/closure-compiler/pull/3036 is in a release, the cli script can be significantly simplified.

Rather than the cli script reading the input files and passing them into the compiler, just use the `--js` and `--extern` flags and let them be loaded from the filesystem directly.

Also adds support to the cli to create the output files and associated directories when either the `--js_output_file` or `--chunk` flags are specified. Creates source map files on disk when the `--create_source_map` flag is used.
