### PR TITLE
Replace deprecated new Buffer() with Buffer.from()

### DIFF
--- a/test/gulp.js
+++ b/test/gulp.js
@@ -79,11 +79,11 @@ describe('gulp-google-closure-compiler', function() {
 
       const fakeFile1 = new File({
         path: '/foo.js',
-        contents: new Buffer('console.log("foo");')
+        contents: Buffer.from('console.log("foo");')
       });
       const fakeFile2 = new File({
         path: '/bar.js',
-        contents: new Buffer('console.log("bar");')
+        contents: Buffer.from('console.log("bar");')
       });
 
       const fixturesCompiled = 'function log(a){console.log(a)}log("one.js");' +


### PR DESCRIPTION
It shows deprecation warnings in Node v10.