### PR TITLE
Fail the build scripts if any single command fails

### DIFF
--- a/build-scripts/build.sh
+++ b/build-scripts/build.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-./build-scripts/build_compiler.js "$@"
-yarn workspaces run build "$@"
+# Run the build commands and fail the script if any of them failed
+./build-scripts/build_compiler.js "$@" && yarn workspaces run build "$@"

--- a/build-scripts/test.sh
+++ b/build-scripts/test.sh
@@ -1,3 +1,6 @@
 #!/usr/bin/env bash
-yarn workspaces run test "$@"
-mocha "$@"
+# Run the test commands and fail the script if any of them failed
+EXIT_STATUS=0
+yarn workspaces run test "$@" || EXIT_STATUS=$?
+mocha "$@" || EXIT_STATUS=$?
+exit $EXIT_STATUS


### PR DESCRIPTION
If any single command in either the build or test script fails, the entire script should have a failing exit status.