### PR TITLE
Enable the reflection needed for conformance configs to operate in Graal

### DIFF
--- a/build-scripts/reflection-config.json
+++ b/build-scripts/reflection-config.json
@@ -245,5 +245,47 @@
     "allDeclaredFields" : true,
     "allPublicMethods" : true,
     "allPublicFields" : true
+  },
+  {
+    "name" : "com.google.javascript.jscomp.Requirement",
+    "allDeclaredMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicMethods" : true,
+    "allPublicFields" : true
+  },
+  {
+    "name" : "com.google.javascript.jscomp.Requirement$Builder",
+    "allDeclaredMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicMethods" : true,
+    "allPublicFields" : true
+  },
+  {
+    "name" : "com.google.javascript.jscomp.Requirement$WhitelistEntry",
+    "allDeclaredMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicMethods" : true,
+    "allPublicFields" : true
+  },
+  {
+    "name" : "com.google.javascript.jscomp.Requirement$Type",
+    "allDeclaredMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicMethods" : true,
+    "allPublicFields" : true
+  },
+  {
+    "name" : "com.google.javascript.jscomp.Requirement$TypeMatchingStrategy",
+    "allDeclaredMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicMethods" : true,
+    "allPublicFields" : true
+  },
+  {
+    "name" : "com.google.javascript.jscomp.Requirement$Severity",
+    "allDeclaredMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicMethods" : true,
+    "allPublicFields" : true
   }
 ]


### PR DESCRIPTION
Fixes #109 

Additional reflection was needed to support conformance configs under Graal.