### PR TITLE
Fix typo

### DIFF
--- a/packages/google-closure-compiler/lib/gulp/index.js
+++ b/packages/google-closure-compiler/lib/gulp/index.js
@@ -184,7 +184,7 @@ module.exports = function(initOptions) {
         });
 
         compilerProcess.stdin.on('error', err => {
-          this.emit('Error', new PluginError(this.PLUGIN_NAME_,
+          this.emit('error', new PluginError(this.PLUGIN_NAME_,
               'Error writing to stdin of the compiler.\n' + err.message));
           cb();
         });


### PR DESCRIPTION
All other uses in the file are `this.emit('error', ...)` with lowercase 'e', so this one is presumably a typo.