### PR TITLE
Publish a nightly releases of the compiler to npm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,13 @@ before_script: yarn run build --colors=always
 
 script: yarn test --colors
 
-before_deploy: build-scripts/add-os-restrictions.js
+before_deploy:
+  # If this is the daily cron job, create a nightly release version
+  - if [ $COMPILER_NIGHTLY = "1" ]; then build-scripts/create-nightly-version.js; fi
+  # The linux and osx packages need OS restrictions added to their package.json files.
+  # This cannot be added before now or the workspace install breaks.
+  # This leaves the working directory dirty so must be the last command before publication.
+  - build-scripts/add-os-restrictions.js
 
 deploy:
   skip_cleanup: true

--- a/build-scripts/create-nightly-version.js
+++ b/build-scripts/create-nightly-version.js
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+/*
+ * Copyright 2018 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Create a nightly version of the package to publish to npm.
+ * The compiler in this version will be a snapshot version.
+ */
+
+const {spawnSync} = require('child_process');
+
+const today = new Date();
+const month = (today.getMonth() < 9 ? '0' : '') + (today.getMonth() + 1).toString();
+const day = (today.getDate() < 10 ? '0' : '') + today.getDate().toString();
+
+// Version number is today's date with a -nightly prerelease suffix.
+const nightlyVersion = `${today.getFullYear()}${month}${day}.0.0-nightly`;
+
+// Lerna won't release packages on an already release tagged commit.
+// Create a new empty commit for this nightly release.
+spawnSync(
+    'git',
+    [
+      'commit',
+      '--allow-empty',
+      '-m',
+      `Create version for nightly release ${nightlyVersion}`
+    ],
+    {
+      stdio: 'inherit',
+    });
+
+const glob = require('glob');
+
+// Get the list of packages in this repo
+const packages = glob.sync('packages/google-closure-compiler*')
+    .map(packagePath => packagePath.replace('packages/', ''));
+
+// Create a nightly version of all the packages
+spawnSync(
+    'node_modules/.bin/lerna',
+    [
+      'version',
+      nightlyVersion,
+      '--push=false', // prevent the version commit from being pushed back to the repo
+      `--force-publish=${packages.join(',')}`, // publish every package even though no changes are detected
+      '--yes', // don't prompt for confirmation
+    ],
+    {
+      stdio: 'inherit',
+    });

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "homepage": "https://developers.google.com/closure/compiler/",
   "dependencies": {},
   "devDependencies": {
+    "glob": "^7.1.3",
     "lerna": "^3.4.1",
     "mocha": "5.2.0",
     "ncp": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2199,7 +2199,7 @@ glob@^4.3.1:
     minimatch "^2.0.1"
     once "^1.3.0"
 
-glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
+glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
   integrity sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==


### PR DESCRIPTION
We publish nightly snapshot releases to maven, but we haven't done the same with npm. This forces most developers to wait for the next release to adopt changes - or possibly even help test changes.

This PR utilizes the nightly travis cron job to publish a snapshot build of the compiler to npm on all platforms. The packages are published with a "nightly" tag so they won't be auto-installed by users unless they opt-in to a specific version number or install with `npm install google-closure-compiler@nightly`.