### PR TITLE
Add a catch to the gulp plugin promise to report unknown errors

### DIFF
--- a/packages/google-closure-compiler/lib/gulp/index.js
+++ b/packages/google-closure-compiler/lib/gulp/index.js
@@ -28,12 +28,17 @@
 
 'use strict';
 
+/**
+ * Rethrow an error with a custom message.
+ * @see https://stackoverflow.com/a/42755876/1211524
+ */
 class CustomError extends Error {
   constructor(plugin, message) {
     if (message instanceof Error) {
       super(`Error in ${plugin}`);
-      this.original = message
-      this.stack = `${this.stack.split('\n').slice(0,2).join('\n')}\n${this.stack}`;
+      this.original = message;
+      // Compose both the current stack and the original stack
+      this.stack = `${this.stack.split('\n').slice(0,2).join('\n')}\n${message.stack}`;
     } else {
       super(`${plugin}: ${message}`);
     }

--- a/packages/google-closure-compiler/lib/gulp/index.js
+++ b/packages/google-closure-compiler/lib/gulp/index.js
@@ -212,6 +212,9 @@ module.exports = function(initOptions) {
 
           this._compilationComplete(code, outputFiles, stdErrData);
           cb();
+        }).catch(err => {
+          this.emit('error', new PluginError(this.PLUGIN_NAME_, err, { showStack: true }));
+          cb();
         });
 
         const stdInStream = new stream.Readable({ read: function() {}});
@@ -222,15 +225,15 @@ module.exports = function(initOptions) {
     }
 
     _compilationComplete(exitCode, compiledJs, errors) {
-      // non-zero exit means a compilation error
-      if (exitCode !== 0) {
-        this.emit('error', new PluginError(this.PLUGIN_NAME_, `Compilation error: ${errors}`));
-      }
-
       // standard error will contain compilation warnings, log those
       if (errors && errors.trim().length > 0) {
         const logger = this.logger_.warn ? this.logger_.warn : this.logger_;
         logger(`${chalk.yellow(this.PLUGIN_NAME_)}: ${errors}`);
+      }
+
+      // non-zero exit means a compilation error
+      if (exitCode !== 0) {
+        this.emit('error', new PluginError(this.PLUGIN_NAME_, `Compilation errors occurred`));
       }
 
       // If present, standard output will be a string of JSON encoded files.

--- a/packages/google-closure-compiler/lib/gulp/index.js
+++ b/packages/google-closure-compiler/lib/gulp/index.js
@@ -30,7 +30,13 @@
 
 class CustomError extends Error {
   constructor(plugin, message) {
-    super(`${plugin}: ${message}`);
+    if (message instanceof Error) {
+      super(`Error in ${plugin}`);
+      this.original = message
+      this.stack = `${this.stack.split('\n').slice(0,2).join('\n')}\n${this.stack}`;
+    } else {
+      super(`${plugin}: ${message}`);
+    }
   }
 }
 

--- a/packages/google-closure-compiler/test/gulp.js
+++ b/packages/google-closure-compiler/test/gulp.js
@@ -187,41 +187,39 @@ describe('gulp-google-closure-compiler', function() {
         stream.end();
       });
 
-      if (platform !== 'javascript') {
-        it('should compile multiple inputs into multiple outputs with chunk options', done => {
-          const stream = closureCompiler({
-            compilation_level: 'SIMPLE',
-            warning_level: 'VERBOSE',
-            chunk: [
-              'one:1',
-              'two:1'
-            ],
-            createSourceMap: true
-          }, {
-            platform
-          });
-
-          // The compiler outputs a file named $weeak$.js which is empty.
-          // It's used to hold weak dependency that were imported for type information only.
-          // Exclude it from test assertions.
-          stream
-              .pipe(streamFilter(['**', '!**/$weak$.js']))
-              .pipe(assert.length(2))
-              .pipe(assert.first(f => {
-                f.contents.toString().trim().should.eql(fakeFile1.contents.toString());
-                f.path.should.eql('one.js');
-              }))
-              .pipe(assert.second(f => {
-                f.contents.toString().trim().should.eql(fakeFile2.contents.toString());
-                f.path.should.eql('two.js');
-              }))
-              .pipe(assert.end(done));
-
-          stream.write(fakeFile1);
-          stream.write(fakeFile2);
-          stream.end();
+      it('should compile multiple inputs into multiple outputs with chunk options', done => {
+        const stream = closureCompiler({
+          compilation_level: 'SIMPLE',
+          warning_level: 'VERBOSE',
+          chunk: [
+            'one:1',
+            'two:1'
+          ],
+          createSourceMap: true
+        }, {
+          platform
         });
-      }
+
+        // The compiler outputs a file named $weeak$.js which is empty.
+        // It's used to hold weak dependency that were imported for type information only.
+        // Exclude it from test assertions.
+        stream
+            .pipe(streamFilter(['**', '!**/$weak$.js']))
+            .pipe(assert.length(2))
+            .pipe(assert.first(f => {
+              f.contents.toString().trim().should.eql(fakeFile1.contents.toString());
+              f.path.should.eql('one.js');
+            }))
+            .pipe(assert.second(f => {
+              f.contents.toString().trim().should.eql(fakeFile2.contents.toString());
+              f.path.should.eql('two.js');
+            }))
+            .pipe(assert.end(done));
+
+        stream.write(fakeFile1);
+        stream.write(fakeFile2);
+        stream.end();
+      });
 
       it('should generate a sourcemap for a single output file', done => {
         gulp.src('test/fixtures/**/*.js', {base: './'})
@@ -240,38 +238,36 @@ describe('gulp-google-closure-compiler', function() {
           .pipe(assert.end(done));
       });
 
-      if (platform !== 'javascript') {
-        it('should generate a sourcemap for each output file with chunks', done => {
-          gulp.src([__dirname + '/fixtures/one.js', __dirname + '/fixtures/two.js'])
-              .pipe(sourcemaps.init())
-              .pipe(closureCompiler({
-                compilation_level: 'SIMPLE',
-                warning_level: 'VERBOSE',
-                chunk: [
-                  'one:1',
-                  'two:1:one'
-                ],
-                createSourceMap: true
-              }, {
-                debugLog: true,
-                platform
-              }))
-              // The compiler outputs a file named $weeak$.js which is empty.
-              // It's used to hold weak dependency that were imported for type information only.
-              // Exclude it from test assertions.
-              .pipe(streamFilter(['**', '!**/$weak$.js']))
-              .pipe(assert.length(2))
-              .pipe(assert.first(f => {
-                f.sourceMap.sources.should.have.length(1);
-                f.sourceMap.file.should.eql('./one.js');
-              }))
-              .pipe(assert.second(f => {
-                f.sourceMap.sources.should.have.length(1);
-                f.sourceMap.file.should.eql('./two.js');
-              }))
-              .pipe(assert.end(done));
-        });
-      }
+      it('should generate a sourcemap for each output file with chunks', done => {
+        gulp.src([__dirname + '/fixtures/one.js', __dirname + '/fixtures/two.js'])
+            .pipe(sourcemaps.init())
+            .pipe(closureCompiler({
+              compilation_level: 'SIMPLE',
+              warning_level: 'VERBOSE',
+              chunk: [
+                'one:1',
+                'two:1:one'
+              ],
+              createSourceMap: true
+            }, {
+              debugLog: true,
+              platform
+            }))
+            // The compiler outputs a file named $weeak$.js which is empty.
+            // It's used to hold weak dependency that were imported for type information only.
+            // Exclude it from test assertions.
+            .pipe(streamFilter(['**', '!**/$weak$.js']))
+            .pipe(assert.length(2))
+            .pipe(assert.first(f => {
+              f.sourceMap.sources.should.have.length(1);
+              f.sourceMap.file.should.eql('./one.js');
+            }))
+            .pipe(assert.second(f => {
+              f.sourceMap.sources.should.have.length(1);
+              f.sourceMap.file.should.eql('./two.js');
+            }))
+            .pipe(assert.end(done));
+      });
 
       if (platform !== 'javascript') {
         it('should support passing input globs directly to the compiler', done => {


### PR DESCRIPTION
The gulp plugin had a promise without a catch clause. Apparently it was possible to trigger a rejection on that promise (though I've never really seen it).

Add a catch clause and report the error with a stack trace.

Fixes #122 