### PR TITLE
Add a clean build script to facilitate removing build artifacts

### DIFF
--- a/build-scripts/clean.sh
+++ b/build-scripts/clean.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+rm -rf ./packages/google-closure-compiler/contrib
+rm ./packages/google-closure-compiler-java/compiler.jar
+rm ./packages/google-closure-compiler-js/jscomp.js
+rm ./packages/google-closure-compiler-linux/compiler.jar
+rm ./packages/google-closure-compiler-linux/compiler
+rm ./packages/google-closure-compiler-osx/compiler.jar
+rm ./packages/google-closure-compiler-osx/compiler
+cd ./compiler && mvn clean

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "scripts": {
     "build": "./build-scripts/build.sh",
-    "test": "./build-scripts/test.sh"
+    "test": "./build-scripts/test.sh",
+    "clean": "./build-scripts/clean.sh"
   }
 }


### PR DESCRIPTION
Helps with local debugging. Run `yarn clean` before `yarn build` to ensure that new compiler artifacts are used.