### PR TITLE
For gulp, delay writing to stdin

### DIFF
--- a/packages/google-closure-compiler/lib/gulp/index.js
+++ b/packages/google-closure-compiler/lib/gulp/index.js
@@ -116,7 +116,7 @@ module.exports = function(initOptions) {
 
     _transform(file, enc, cb) {
       // ignore empty files
-      if (file.isNull()) {
+      if (!file || file.isNull()) {
         cb();
         return;
       }
@@ -143,7 +143,7 @@ module.exports = function(initOptions) {
       } else {
         // If files in the stream were required, no compilation needed here.
         if (this._streamInputRequired) {
-          this.emit('end');
+          this.push(null);
           cb();
           return;
         }
@@ -230,8 +230,10 @@ module.exports = function(initOptions) {
 
         const stdInStream = new stream.Readable({ read: function() {}});
         stdInStream.pipe(compilerProcess.stdin);
-        stdInStream.push(JSON.stringify(jsonFiles));
-        stdInStream.push(null);
+        process.nextTick(() => {
+          stdInStream.push(JSON.stringify(jsonFiles));
+          stdInStream.push(null);
+        });
       }
     }
 


### PR DESCRIPTION
Allow time to detect that the external process successfully started.

Better detects launch errors (such as when invalid flags are passed) before attempting to write to stdin.

Hopefully, this addresses #130