### PR TITLE
Don't swallow unexpected exceptions from the JS version in the gulp plugin

### DIFF
--- a/packages/google-closure-compiler/lib/gulp/index.js
+++ b/packages/google-closure-compiler/lib/gulp/index.js
@@ -161,7 +161,13 @@ module.exports = function(initOptions) {
             cb();
           });
         } catch (e) {
-          this._compilationComplete(1, [], e.message.replace(/^java.lang.RuntimeException: /, ''));
+          let errors = e.stack;
+          // Special case for the exception thrown for an invalid flag
+          if (/Bad value for | Unhandled flag: /.test(e.message)) {
+            errors = e.message.replace(/^(java\.lang\.RuntimeException|Class[a-zA-Z0-9_\$]+): /, '');
+          }
+
+          this._compilationComplete(1, [], errors);
           cb();
           return;
         }
@@ -232,6 +238,12 @@ module.exports = function(initOptions) {
       }
     }
 
+    /**
+     * @param {number} exitCode
+     * @param {string} compiledJs
+     * @param {string} errors
+     * @private
+     */
     _compilationComplete(exitCode, compiledJs, errors) {
       // standard error will contain compilation warnings, log those
       if (errors && errors.trim().length > 0) {

--- a/packages/google-closure-compiler/test/gulp.js
+++ b/packages/google-closure-compiler/test/gulp.js
@@ -99,7 +99,22 @@ describe('gulp-google-closure-compiler', function() {
         platformUtilized = undefined;
       });
 
-      it('should emit an error for invalid options', done => {
+      it('should emit an error for invalid flag', done => {
+        const stream = closureCompiler({
+          foo: 'BAR'
+        }, {
+          platform
+        });
+
+        stream.on('error', err => {
+          err.message.should.match(/^(gulp-google-closure-compiler: )?Compilation error/);
+          done();
+        });
+        stream.write(fakeFile1);
+        stream.end();
+      });
+
+      it('should emit an error for a flag with an invalid value', done => {
         const stream = closureCompiler({
           compilation_level: 'FOO'
         }, {


### PR DESCRIPTION
Special case the exceptions thrown for invalid flags and values, but pass the full stack trace for any other error. Will significantly improve debugging of the JS version.