### PR TITLE
Grunt option compile_in_batches to optionally compile not all files in parallel

### DIFF
--- a/packages/google-closure-compiler/docs/grunt.md
+++ b/packages/google-closure-compiler/docs/grunt.md
@@ -28,6 +28,7 @@ grunt.initConfig({
         'dest/output.min.js': ['src/js/**/*.js']
       },
       options: {
+        compile_in_batches: require('os').cpus().length,
         compilation_level: 'SIMPLE',
         language_in: 'ECMASCRIPT5_STRICT',
         create_source_map: 'dest/output.min.js.map',

--- a/packages/google-closure-compiler/lib/grunt/index.js
+++ b/packages/google-closure-compiler/lib/grunt/index.js
@@ -35,6 +35,7 @@ module.exports = (grunt, pluginOptions) => {
 
   let extraArguments;
   let platforms;
+  let compileInBatches = false;
   if (pluginOptions) {
     if (Array.isArray(extraArguments)) {
       extraArguments = pluginOptions;
@@ -47,6 +48,9 @@ module.exports = (grunt, pluginOptions) => {
       if (pluginOptions.extraArguments) {
         extraArguments = pluginOptions.extraArguments;
       }
+    }
+    if (pluginOptions instanceof Object && typeof pluginOptions.compile_in_batches === 'number' && pluginOptions.compile_in_batches > 0) {
+      compileInBatches = pluginOptions.compile_in_batches;
     }
   }
 
@@ -65,6 +69,10 @@ module.exports = (grunt, pluginOptions) => {
       this.push(file);
       cb();
     }
+  }
+
+  function compilationPromiseGenerator(files, options, pluginOpts) {
+    return function () { return compilationPromise(files, options, pluginOpts); };
   }
 
   /**
@@ -194,27 +202,44 @@ module.exports = (grunt, pluginOptions) => {
         options.compilerOpts.js_output_file = f.dest;
       }
 
-      compileTasks.push(compilationPromise(src, options.args || options.compilerOpts, {platform})
-          .then(function () {}, function(err) {
-            throw err;
-          }));
+      compileTasks.push(compilationPromiseGenerator(src, options.args || options.compilerOpts, {platform}));
     });
 
     // If the task was invoked without any files provided by grunt, assume that
     // --js flags are present and we want to run the compiler anyway.
     if (taskObject.files.length === 0) {
       const options = getCompilerOptions();
-      compileTasks.push(compilationPromise(null, options.args || options.compilerOpts, {platform}));
+      compileTasks.push(compilationPromiseGenerator(null, options.args || options.compilerOpts, {platform}));
     }
 
     // Multiple invocations of the compiler can occur for a single task target. Wait until
     // they are all completed before calling the "done" method.
-    Promise.all(compileTasks)
+
+    return compileInBatches ? processPromises(compileTasks, asyncDone) : Promise.all(compileTasks.map(t => t()))
       .then(() => asyncDone())
       .catch(() => {
         grunt.fail.warn('Compilation error');
         asyncDone();
       });
+  }
+
+  function processPromises(ps, done) {
+    if (!ps.length) {
+      done();
+      return;
+    }
+    let psb = [];
+    for (let i = 0; i < compileInBatches; i++) {
+      if (ps.length) {
+        psb.push(ps.pop());
+      }
+    }
+    return Promise.all(psb.map(t => t())).then(() => {
+      return processPromises(ps, done);
+    }).catch((e) => {
+      grunt.fail.warn('Compilation error');
+      done();
+    });
   }
 
   grunt.registerMultiTask('closure-compiler',


### PR DESCRIPTION
Hello!

We use compilator with grunt config like:
```
        files: [{
          expand: true,
          src: [
            'built/bin/**/*.js',
            'built/bootstrap/**/*.js',
            'built/cron/**/*.js',
            'built/lib/**/*.js',
            'built/models/**/*.js',
            'built/rest/**/*.js',
            'built/routes/**/*.js',

            'built/controllers/**/main.js',
            'built/controllers/**/master.js',
            'built/controllers-modules/**/*.js'
          ],
          dest: '.builttemp',
          cwd: '.'
        }],
```

Grunt plugin by default creates ton of parallel compiler processes and jenkins crashes.

Made useful option to restrict number of parallel compiler processes. Default for compiling all files at once not changed.
