### PR TITLE
Grunt option compile_in_batches to optionally compile not all files in parallel

### DIFF
--- a/packages/google-closure-compiler/docs/grunt.md
+++ b/packages/google-closure-compiler/docs/grunt.md
@@ -7,7 +7,8 @@ Include the plugin in your Gruntfile.js:
 
 ```js
 require('google-closure-compiler').grunt(grunt, {
-  platform: ['native', 'java', 'javascript']
+  platform: ['native', 'java', 'javascript'],
+  compile_in_batches: require('os').cpus().length
 });
 // The load-grunt-tasks plugin won't automatically load closure-compiler
 ```
@@ -28,7 +29,6 @@ grunt.initConfig({
         'dest/output.min.js': ['src/js/**/*.js']
       },
       options: {
-        compile_in_batches: require('os').cpus().length,
         compilation_level: 'SIMPLE',
         language_in: 'ECMASCRIPT5_STRICT',
         create_source_map: 'dest/output.min.js.map',

--- a/packages/google-closure-compiler/docs/grunt.md
+++ b/packages/google-closure-compiler/docs/grunt.md
@@ -28,6 +28,7 @@ grunt.initConfig({
         'dest/output.min.js': ['src/js/**/*.js']
       },
       options: {
+        compile_in_batches: require('os').cpus().length,
         compilation_level: 'SIMPLE',
         language_in: 'ECMASCRIPT5_STRICT',
         create_source_map: 'dest/output.min.js.map',

--- a/packages/google-closure-compiler/lib/grunt/index.js
+++ b/packages/google-closure-compiler/lib/grunt/index.js
@@ -224,14 +224,24 @@ module.exports = (grunt, pluginOptions) => {
       });
   }
 
-  // processPromises function grabs `ps` as array of promise-returning functions and `done` function as callback. It separates `ps` into batches of length == compileInBatches and runs resulting batches in parallel.
+  // 
+  /**
+   * Grabs `ps` as array of promise-returning functions and `done` function as callback.
+   * Separates ps` into batches of length == compileInBatches and runs resulting 
+   * promises in batches in parallel but batches in series.
+   * 
+   * @param {Array<Function(...?):Promise>}} functions returning promises
+   * @param {Function(null)} callback for the end of processing
+   * @return {Promise}
+   */
   function processPromises(ps, done) {
     // if no promise-returning functions in array - it's done
     if (!ps.length) {
       done();
       return;
     }
-    // else forming psb array with `compileInBatches` or less promise-returning functions and running it in parallel
+    // else forming psb array with `compileInBatches` or less promise-returning functions
+    // and running it in parallel
     let psb = [];
     for (let i = 0; i < compileInBatches; i++) {
       if (ps.length) {
@@ -240,7 +250,8 @@ module.exports = (grunt, pluginOptions) => {
     }
     // for each promise returning function run that function to make promise running 
     return Promise.all(psb.map(t => t())).then(() => {
-      // when all promises in batch fulfilled run itself with main `ps` array (or what it has for now)
+      // when all promises in batch fulfilled run itself with main `ps` array
+      // (or what it has for now)
       return processPromises(ps, done);
     }).catch((e) => {
       // if some error in promise - failing

--- a/packages/google-closure-compiler/lib/grunt/index.js
+++ b/packages/google-closure-compiler/lib/grunt/index.js
@@ -224,15 +224,14 @@ module.exports = (grunt, pluginOptions) => {
       });
   }
 
-  // 
   /**
    * Grabs `ps` as array of promise-returning functions and `done` function as callback.
    * Separates ps` into batches of length == compileInBatches and runs resulting 
    * promises in batches in parallel but batches in series.
    * 
-   * @param {Array<Function(...?):Promise>}} functions returning promises
-   * @param {Function(null)} callback for the end of processing
-   * @return {Promise}
+   * @param {!Array<function():!Promise<undefined>>} ps functions returning promises
+   * @param {function():undefined} done callback for the end of processing
+   * @return {!Promise<undefined>|undefined}
    */
   function processPromises(ps, done) {
     // if no promise-returning functions in array - it's done


### PR DESCRIPTION
Hello!

We use compilator with grunt config like:
```
        files: [{
          expand: true,
          src: [
            'built/bin/**/*.js',
            'built/bootstrap/**/*.js',
            'built/cron/**/*.js',
            'built/lib/**/*.js',
            'built/models/**/*.js',
            'built/rest/**/*.js',
            'built/routes/**/*.js',

            'built/controllers/**/main.js',
            'built/controllers/**/master.js',
            'built/controllers-modules/**/*.js'
          ],
          dest: '.builttemp',
          cwd: '.'
        }],
```

Grunt plugin by default creates ton of parallel compiler processes and jenkins crashes.

Made useful option to restrict number of parallel compiler processes. Default for compiling all files at once not changed.
