### PR TITLE
Do not blindly create directories like 'C:\' in mkDirByPathSync

### DIFF
--- a/packages/google-closure-compiler/cli.js
+++ b/packages/google-closure-compiler/cli.js
@@ -29,7 +29,9 @@ function mkDirByPathSync(targetDir, {isRelativeToScript = false} = {}) {
   targetDir.split(sep).reduce((parentDir, childDir) => {
     const curDir = path.resolve(baseDir, parentDir, childDir);
     try {
-      fs.mkdirSync(curDir);
+      if (!fs.existsSync(curDir)) {
+        fs.mkdirSync(curDir);
+      }
     } catch (err) {
       if (err.code !== 'EEXIST') {
         throw err;


### PR DESCRIPTION
Do not blindly create directories like 'C:\' in mkDirByPathSync, but check if the directory exists first. #161