### PR TITLE
Add better logging to js testing

### DIFF
--- a/packages/google-closure-compiler-js/test.js
+++ b/packages/google-closure-compiler-js/test.js
@@ -22,6 +22,7 @@ try {
   require('./');
   process.stdout.write(`  ${GREEN}✓${RESET} ${DIM}jscomp exists${RESET}\n`);
 } catch (e) {
-  process.stdout.write(`  ${RED}jscomp does not exist${RESET}\n`);
+  process.stdout.write(`  ${RED}error loading jscomp${RESET}\n`);
+  console.error(e);
   process.exitCode = 1;
 }


### PR DESCRIPTION
Right now this test is giving an incorrect error at best, and a misleading error at worst. I encountered this trying to debug the closure-compiler CI, and found that there was a real error loading this package that wasn't getting logged. Adding the `console.log` here ensures the error is well formatted with a stack trace and everything.