### PR TITLE
Force binary packages to be unplugged when using Yarn's pnp

### DIFF
--- a/packages/google-closure-compiler-java/package.json
+++ b/packages/google-closure-compiler-java/package.json
@@ -21,6 +21,7 @@
     "package.json",
     "readme.md"
   ],
+  "preferUnplugged": true,
   "scripts": {
     "build": "echo \"google-closure-compiler-java build\"",
     "test": "./test.js"

--- a/packages/google-closure-compiler-linux/package.json
+++ b/packages/google-closure-compiler-linux/package.json
@@ -25,6 +25,7 @@
     "x64",
     "x86"
   ],
+  "preferUnplugged": true,
   "scripts": {
     "build": "./build-image.js",
     "test": "./test.js"

--- a/packages/google-closure-compiler-osx/package.json
+++ b/packages/google-closure-compiler-osx/package.json
@@ -25,6 +25,7 @@
     "x64",
     "x86"
   ],
+  "preferUnplugged": true,
   "scripts": {
     "build": "./build-image.js",
     "test": "./test.js"

--- a/packages/google-closure-compiler-windows/package.json
+++ b/packages/google-closure-compiler-windows/package.json
@@ -24,6 +24,7 @@
     "x64",
     "x86"
   ],
+  "preferUnplugged": true,
   "scripts": {
     "build": "node build-image.js",
     "test": "./test.js"


### PR DESCRIPTION
Fixes the issue in #168 with the binary packages (`google-closure-compiler-osx`, etc) not being unplugged in Yarn's plug-n-play. I set the preferUnplugged in `package.json`s of each affected package.

Test
```
mkdir test-unplugged
cd test-unplugged
yarn set version berry
yarn init
yarn add /Users/seamusleahy/projects/closure-compiler-npm/packages/google-closure-compiler-osx
cd .yarn/unplugged
ls
```
Expect to see a `google-closure-compiler-osx-<source>-<hash>` folder with all the contents of the package. If it doesn't work, then it will not have a folder inside of `.yarn/unplugged`.