### PR TITLE
Mark the downloaded binaries as executable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -282,6 +282,11 @@ jobs:
         with:
           name: Contrib folder
           path: packages/google-closure-compiler/contrib
+      - name: Mark binaries executable
+        run: |
+          chmod 755 packages/google-closure-compiler-linux/compiler
+          chmod 755 packages/google-closure-compiler-osx/compiler
+          chmod 755 packages/google-closure-compiler-windows/compiler.exe
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"


### PR DESCRIPTION
Add a build step to explicitly mark the downloaded artifacts as executable

Fixes #188