### PR TITLE
Treat --platform flag as a preferences ordered list in cli.js

### DIFF
--- a/packages/google-closure-compiler/cli.js
+++ b/packages/google-closure-compiler/cli.js
@@ -17,11 +17,14 @@
 'use strict';
 const fs = require('fs');
 const path = require('path');
-const {getNativeImagePath, getFirstSupportedPlatform} = require('./lib/utils');
+const {
+  getNativeImagePath,
+  getFirstSupportedPlatform,
+} = require('./lib/utils');
 const parseArgs = require('minimist');
 
 /** @see https://stackoverflow.com/a/40686853/1211524 */
-function mkDirByPathSync(targetDir, {isRelativeToScript = false} = {}) {
+function mkDirByPathSync(targetDir, { isRelativeToScript = false } = {}) {
   const sep = path.sep;
   const initDir = path.isAbsolute(targetDir) ? sep : '';
   const baseDir = isRelativeToScript ? __dirname : '.';
@@ -48,7 +51,7 @@ const compilerFlags = parseArgs(process.argv.slice(2));
 // If it exists, use the value, but then delete it so that it's not actually passed to the compiler.
 let platform;
 if (compilerFlags.hasOwnProperty('platform')) {
-  platform = compilerFlags.platform;
+  platform = getFirstSupportedPlatform(compilerFlags.platform.split(','));
   delete compilerFlags.platform;
 } else {
   platform = getFirstSupportedPlatform(['native', 'java']);
@@ -75,7 +78,7 @@ if (compilerFlags.hasOwnProperty('_') && compilerFlags['_'].length > 0) {
 // Boolean arguments can in some cases be parsed as strings.
 // Since its highly unlikely that an argument actually needs to be the strings 'true' or 'false',
 // convert them to true booleans.
-Object.keys(compilerFlags).forEach(flag => {
+Object.keys(compilerFlags).forEach((flag) => {
   if (compilerFlags[flag] === 'true') {
     compilerFlags[flag] = true;
   } else if (compilerFlags[flag] === 'false') {
@@ -98,7 +101,7 @@ for (let i = 0; i < args.length; i++) {
 
 const compiler = new Compiler(args);
 
-compiler.spawnOptions = {stdio: 'inherit'};
+compiler.spawnOptions = { stdio: 'inherit' };
 if (platform === 'native') {
   compiler.JAR_PATH = null;
   compiler.javaPath = getNativeImagePath();

--- a/packages/google-closure-compiler/cli.js
+++ b/packages/google-closure-compiler/cli.js
@@ -17,14 +17,11 @@
 'use strict';
 const fs = require('fs');
 const path = require('path');
-const {
-  getNativeImagePath,
-  getFirstSupportedPlatform,
-} = require('./lib/utils');
+const {getNativeImagePath, getFirstSupportedPlatform} = require('./lib/utils');
 const parseArgs = require('minimist');
 
 /** @see https://stackoverflow.com/a/40686853/1211524 */
-function mkDirByPathSync(targetDir, { isRelativeToScript = false } = {}) {
+function mkDirByPathSync(targetDir, {isRelativeToScript = false} = {}) {
   const sep = path.sep;
   const initDir = path.isAbsolute(targetDir) ? sep : '';
   const baseDir = isRelativeToScript ? __dirname : '.';
@@ -101,7 +98,7 @@ for (let i = 0; i < args.length; i++) {
 
 const compiler = new Compiler(args);
 
-compiler.spawnOptions = { stdio: 'inherit' };
+compiler.spawnOptions = {stdio: 'inherit'};
 if (platform === 'native') {
   compiler.JAR_PATH = null;
   compiler.javaPath = getNativeImagePath();


### PR DESCRIPTION
Currently --platform is read as a single string if present and the value defaults to a preference ordered list if not specified. After this change it will be a comma separated list when present. This also means that invalid platform specifiers will throw an error.

Closes https://github.com/google/closure-compiler-npm/issues/197