### PR TITLE
Delete BanExpose entry in reflection config

### DIFF
--- a/build-scripts/reflection-config.json
+++ b/build-scripts/reflection-config.json
@@ -227,14 +227,6 @@
     "allPublicFields" : true
   },
   {
-    "name" : "com.google.javascript.jscomp.ConformanceRules$BanExpose",
-    "methods" : [ { "name" : "<init>" } ],
-    "allDeclaredMethods" : true,
-    "allDeclaredFields" : true,
-    "allPublicMethods" : true,
-    "allPublicFields" : true
-  },
-  {
     "name" : "com.google.javascript.jscomp.ConformanceRules$BanGlobalVars",
     "methods" : [ { "name" : "<init>" } ],
     "allDeclaredMethods" : true,


### PR DESCRIPTION
The conformance rule has been deleted, and hopefully this will fix
the broken build at
https://github.com/google/closure-compiler/runs/2579755422.