### PR TITLE
Update to GRAAL 21.1.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,8 +76,8 @@ jobs:
     env:
       NODE_VERSION: '14.x'
       FORCE_COLOR: '1'
-      GRAAL_VERSION: '21.0.0.2'
-      GRAAL_URL: 'https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.0.0.2/graalvm-ce-java11-linux-amd64-21.0.0.2.tar.gz'
+      GRAAL_VERSION: '21.1.0'
+      GRAAL_URL: 'https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.1.0/graalvm-ce-java11-linux-amd64-21.1.0.tar.gz'
     steps:
       - uses: actions/setup-java@v1
         with:
@@ -133,8 +133,8 @@ jobs:
     env:
       NODE_VERSION: '10.x'
       FORCE_COLOR: '1'
-      GRAAL_VERSION: '21.0.0.2'
-      GRAAL_URL: 'https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.0.0.2/graalvm-ce-java11-darwin-amd64-21.0.0.2.tar.gz'
+      GRAAL_VERSION: '21.1.0'
+      GRAAL_URL: 'https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.1.0/graalvm-ce-java11-darwin-amd64-21.1.0.tar.gz'
     steps:
       - uses: actions/setup-java@v1
         with:
@@ -190,8 +190,8 @@ jobs:
     env:
       NODE_VERSION: '12.x'
       FORCE_COLOR: '1'
-      GRAAL_VERSION: '21.0.0.2'
-      GRAAL_URL: 'https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.0.0.2/graalvm-ce-java11-windows-amd64-21.0.0.2.zip'
+      GRAAL_VERSION: '21.1.0'
+      GRAAL_URL: 'https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.1.0/graalvm-ce-java11-windows-amd64-21.1.0.zip'
     steps:
       - uses: actions/setup-java@v1
         with:

--- a/build-scripts/graal.js
+++ b/build-scripts/graal.js
@@ -54,6 +54,7 @@ const NATIVE_IMAGE_BUILD_ARGS = [
   '-H:IncludeResourceBundles=org.kohsuke.args4j.Messages',
   '-H:IncludeResourceBundles=org.kohsuke.args4j.spi.Messages',
   '-H:IncludeResourceBundles=com.google.javascript.jscomp.parsing.ParserConfig',
+  '-H:+AllowIncompleteClasspath',
   `-H:ReflectionConfigurationFiles=${path.resolve(__dirname, 'reflection-config.json')}`,
   '-H:IncludeResources=(externs.zip)|(.*(js|txt))'.replace(/[\|\(\)]/g, (match) => {
     if (GRAAL_OS === 'windows') {


### PR DESCRIPTION
Add -H:+AllowIncompleteClasspath to the GRAAL compile command as suggested by the Graal project.

Hopefully this produces smaller compiler images