### PR TITLE
Add arm64 to support M1 macs

### DIFF
--- a/packages/google-closure-compiler-osx/package.json
+++ b/packages/google-closure-compiler-osx/package.json
@@ -23,7 +23,8 @@
   ],
   "cpu": [
     "x64",
-    "x86"
+    "x86",
+    "arm64"
   ],
   "preferUnplugged": true,
   "scripts": {


### PR DESCRIPTION
Fixes #211. Allows the package to install on M1 macs. Rosetta properly translates the binary. 