### PR TITLE
Upgrade to GRAAL 21.2.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,8 +76,8 @@ jobs:
     env:
       NODE_VERSION: '14.x'
       FORCE_COLOR: '1'
-      GRAAL_VERSION: '21.0.0.2'
-      GRAAL_URL: 'https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.0.0.2/graalvm-ce-java11-linux-amd64-21.0.0.2.tar.gz'
+      GRAAL_VERSION: '21.2.0'
+      GRAAL_URL: 'https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.2.0/graalvm-ce-java11-linux-amd64-21.2.0.tar.gz'
     steps:
       - uses: actions/setup-java@v1
         with:
@@ -133,8 +133,8 @@ jobs:
     env:
       NODE_VERSION: '10.x'
       FORCE_COLOR: '1'
-      GRAAL_VERSION: '21.0.0.2'
-      GRAAL_URL: 'https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.0.0.2/graalvm-ce-java11-darwin-amd64-21.0.0.2.tar.gz'
+      GRAAL_VERSION: '21.2.0'
+      GRAAL_URL: 'https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.2.0/graalvm-ce-java11-darwin-amd64-21.2.0.tar.gz'
     steps:
       - uses: actions/setup-java@v1
         with:
@@ -190,8 +190,8 @@ jobs:
     env:
       NODE_VERSION: '12.x'
       FORCE_COLOR: '1'
-      GRAAL_VERSION: '21.0.0.2'
-      GRAAL_URL: 'https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.0.0.2/graalvm-ce-java11-windows-amd64-21.0.0.2.zip'
+      GRAAL_VERSION: '21.2.0'
+      GRAAL_URL: 'https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.2.0/graalvm-ce-java11-windows-amd64-21.2.0.zip'
     steps:
       - uses: actions/setup-java@v1
         with:

--- a/build-scripts/graal-env.js
+++ b/build-scripts/graal-env.js
@@ -16,7 +16,7 @@
 'use strict';
 
 const GRAAL_OS = process.platform === 'win32' ? 'windows' : process.platform;
-const GRAAL_VERSION = process.env.GRAAL_VERSION || '21.0.0.2';
+const GRAAL_VERSION = process.env.GRAAL_VERSION || '21.2.0';
 const GRAAL_FOLDER = `graalvm-ce-java11-${GRAAL_OS}-amd64-${GRAAL_VERSION}`;
 const GRAAL_PACKAGE_SUFFIX = GRAAL_OS === 'windows' ? 'zip' : 'tar.gz';
 const GRAAL_URL = process.env.GRAAL_URL ||

--- a/build-scripts/graal.js
+++ b/build-scripts/graal.js
@@ -47,12 +47,11 @@ if (!fs.existsSync(TEMP_PATH)) {
 }
 
 const NATIVE_IMAGE_BUILD_ARGS = [
-  '--no-server',
-  '-H:+JNI',
   '-H:+ReportUnsupportedElementsAtRuntime',
   '-H:IncludeResourceBundles=org.kohsuke.args4j.Messages',
   '-H:IncludeResourceBundles=org.kohsuke.args4j.spi.Messages',
   '-H:IncludeResourceBundles=com.google.javascript.jscomp.parsing.ParserConfig',
+  '-H:+AllowIncompleteClasspath',
   `-H:ReflectionConfigurationFiles=${path.resolve(__dirname, 'reflection-config.json')}`,
   '-H:IncludeResources=(externs.zip)|(.*(js|txt|typedast))'.replace(/[\|\(\)]/g, (match) => {
     if (GRAAL_OS === 'windows') {


### PR DESCRIPTION
Upgrades the GRAAL version to the latest stable version: https://github.com/graalvm/graalvm-ce-builds/releases/tag/vm-21.2.0