### PR TITLE
Bump Bazel version to 4.2.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Bazel
         uses: jwlawson/actions-setup-bazel@v1
         with:
-          bazel-version: '3.4.1'
+          bazel-version: '4.2.2'
       - uses: actions/checkout@v2
         with:
           submodules: recursive


### PR DESCRIPTION
Should fix a CI error (https://github.com/google/closure-compiler-npm/actions/runs/1761399002) caused by https://github.com/google/closure-compiler/commit/c282b0c5280afff1ace3497fa0d5da5f3e7f9dca.