### PR TITLE
Upgrade GRAAL version and JDK build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,9 +19,10 @@ jobs:
       FORCE_COLOR: '1'
     steps:
       - name: Setup Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
-          java-version: '11'
+          distribution: adopt-hotspot
+          java-version: 17
           java-package: jdk
           architecture: x64
       - name: Setup Bazel
@@ -76,12 +77,14 @@ jobs:
     env:
       NODE_VERSION: '14.x'
       FORCE_COLOR: '1'
-      GRAAL_VERSION: '21.0.0.2'
-      GRAAL_URL: 'https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.0.0.2/graalvm-ce-java11-linux-amd64-21.0.0.2.tar.gz'
+      GRAAL_VERSION: '22.0.0.2'
+      GRAAL_URL: 'https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.0.0.2/graalvm-ce-java11-linux-amd64-22.0.0.2.tar.gz'
     steps:
-      - uses: actions/setup-java@v1
+      - name: Setup Java
+        uses: actions/setup-java@v2
         with:
-          java-version: '11'
+          distribution: adopt-hotspot
+          java-version: 17
           java-package: jdk
           architecture: x64
       - uses: actions/checkout@v2
@@ -133,12 +136,14 @@ jobs:
     env:
       NODE_VERSION: '10.x'
       FORCE_COLOR: '1'
-      GRAAL_VERSION: '21.0.0.2'
-      GRAAL_URL: 'https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.0.0.2/graalvm-ce-java11-darwin-amd64-21.0.0.2.tar.gz'
+      GRAAL_VERSION: '22.0.0.2'
+      GRAAL_URL: 'https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.0.0.2/graalvm-ce-java11-darwin-amd64-22.0.0.2.tar.gz'
     steps:
-      - uses: actions/setup-java@v1
+      - name: Setup Java
+        uses: actions/setup-java@v2
         with:
-          java-version: '11'
+          distribution: adopt-hotspot
+          java-version: 17
           java-package: jdk
           architecture: x64
       - uses: actions/checkout@v2
@@ -190,12 +195,14 @@ jobs:
     env:
       NODE_VERSION: '12.x'
       FORCE_COLOR: '1'
-      GRAAL_VERSION: '21.0.0.2'
-      GRAAL_URL: 'https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.0.0.2/graalvm-ce-java11-windows-amd64-21.0.0.2.zip'
+      GRAAL_VERSION: '22.0.0.2'
+      GRAAL_URL: 'https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.0.0.2/graalvm-ce-java11-windows-amd64-22.0.0.2.zip'
     steps:
-      - uses: actions/setup-java@v1
+      - name: Setup Java
+        uses: actions/setup-java@v2
         with:
-          java-version: '11'
+          distribution: adopt-hotspot
+          java-version: 17
           java-package: jdk
           architecture: x64
       - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,7 +134,7 @@ jobs:
     needs: build-compiler
     runs-on: macos-latest
     env:
-      NODE_VERSION: '10.x'
+      NODE_VERSION: '16.x'
       FORCE_COLOR: '1'
       GRAAL_VERSION: '22.0.0.2'
       GRAAL_URL: 'https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.0.0.2/graalvm-ce-java11-darwin-amd64-22.0.0.2.tar.gz'
@@ -193,7 +193,7 @@ jobs:
     needs: build-compiler
     runs-on: windows-latest
     env:
-      NODE_VERSION: '12.x'
+      NODE_VERSION: '17.x'
       FORCE_COLOR: '1'
       GRAAL_VERSION: '22.0.0.2'
       GRAAL_URL: 'https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.0.0.2/graalvm-ce-java11-windows-amd64-22.0.0.2.zip'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,7 +134,7 @@ jobs:
     needs: build-compiler
     runs-on: macos-latest
     env:
-      NODE_VERSION: '16.x'
+      NODE_VERSION: '14.x'
       FORCE_COLOR: '1'
       GRAAL_VERSION: '22.0.0.2'
       GRAAL_URL: 'https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.0.0.2/graalvm-ce-java11-darwin-amd64-22.0.0.2.tar.gz'
@@ -193,7 +193,7 @@ jobs:
     needs: build-compiler
     runs-on: windows-latest
     env:
-      NODE_VERSION: '17.x'
+      NODE_VERSION: '14.x'
       FORCE_COLOR: '1'
       GRAAL_VERSION: '22.0.0.2'
       GRAAL_URL: 'https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.0.0.2/graalvm-ce-java11-windows-amd64-22.0.0.2.zip'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,7 @@ jobs:
     needs: build-compiler
     runs-on: ubuntu-latest
     env:
-      NODE_VERSION: '14.x'
+      NODE_VERSION: '12.x'
       FORCE_COLOR: '1'
       GRAAL_VERSION: '22.0.0.2'
       GRAAL_URL: 'https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.0.0.2/graalvm-ce-java11-linux-amd64-22.0.0.2.tar.gz'
@@ -193,7 +193,7 @@ jobs:
     needs: build-compiler
     runs-on: windows-latest
     env:
-      NODE_VERSION: '14.x'
+      NODE_VERSION: '16.x'
       FORCE_COLOR: '1'
       GRAAL_VERSION: '22.0.0.2'
       GRAAL_URL: 'https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.0.0.2/graalvm-ce-java11-windows-amd64-22.0.0.2.zip'

--- a/build-scripts/graal-env.js
+++ b/build-scripts/graal-env.js
@@ -16,7 +16,7 @@
 'use strict';
 
 const GRAAL_OS = process.platform === 'win32' ? 'windows' : process.platform;
-const GRAAL_VERSION = process.env.GRAAL_VERSION || '21.0.0.2';
+const GRAAL_VERSION = process.env.GRAAL_VERSION || '22.0.0.2';
 const GRAAL_FOLDER = `graalvm-ce-java11-${GRAAL_OS}-amd64-${GRAAL_VERSION}`;
 const GRAAL_PACKAGE_SUFFIX = GRAAL_OS === 'windows' ? 'zip' : 'tar.gz';
 const GRAAL_URL = process.env.GRAAL_URL ||

--- a/build-scripts/graal.js
+++ b/build-scripts/graal.js
@@ -47,12 +47,11 @@ if (!fs.existsSync(TEMP_PATH)) {
 }
 
 const NATIVE_IMAGE_BUILD_ARGS = [
-  '--no-server',
-  '-H:+JNI',
   '-H:+ReportUnsupportedElementsAtRuntime',
   '-H:IncludeResourceBundles=org.kohsuke.args4j.Messages',
   '-H:IncludeResourceBundles=org.kohsuke.args4j.spi.Messages',
   '-H:IncludeResourceBundles=com.google.javascript.jscomp.parsing.ParserConfig',
+  '-H:+AllowIncompleteClasspath',
   `-H:ReflectionConfigurationFiles=${path.resolve(__dirname, 'reflection-config.json')}`,
   '-H:IncludeResources=(externs.zip)|(.*(js|txt|typedast))'.replace(/[\|\(\)]/g, (match) => {
     if (GRAAL_OS === 'windows') {


### PR DESCRIPTION
Followup to https://github.com/google/closure-compiler-npm/pull/220

See if the new GRAAL version and JDK versions will produce smaller binaries.