### PR TITLE
Update the VinylStream class used by the Grunt plugin

### DIFF
--- a/packages/google-closure-compiler/lib/grunt/vinyl-stream.js
+++ b/packages/google-closure-compiler/lib/grunt/vinyl-stream.js
@@ -37,14 +37,7 @@ class VinylStream extends Readable {
 
   _read() {
     if (this._files.length === 0) {
-      this.emit('end');
-      return;
-    }
-    this.readFile();
-  }
-
-  readFile() {
-    if (this._files.length === 0) {
+      this.push(null);
       return;
     }
     const filepath = this._files.shift();
@@ -55,17 +48,11 @@ class VinylStream extends Readable {
         return;
       }
 
-      const file = new File({
+      this.push(new File({
         base: this._base,
         path: fullpath,
         contents: data
-      });
-
-      if (!this.push(file)) {
-        return;
-      } else {
-        this.readFile();
-      }
+      }));
     });
   }
 }


### PR DESCRIPTION
While working on https://github.com/google/closure-compiler-npm/pull/226, the Grunt plugin started failing on newer versions of Node. I was able to replicate this same failure locally.

The grunt streaming code was written long ago. When I reviewed that code, I found several oddities contributing to this failure.

 - Remove the recursive call. The client will re-call read again for us.
 - Push "null" instead of synthetically ending the stream
 - Simplify into a single function call

The tests all pass locally for me now on Node 16 (were failing before). I don't have any projects that use Grunt anymore so we'll have to depend on community feedback to know for sure that this continues to work.

It's possible that this will address the concerns in https://github.com/google/closure-compiler-npm/issues/66