### PR TITLE
Only use native Linux compiler on x86 platforms

### DIFF
--- a/packages/google-closure-compiler/lib/utils.js
+++ b/packages/google-closure-compiler/lib/utils.js
@@ -30,9 +30,11 @@ function getNativeImagePath() {
       return;
     }
   }
-  try {
-    return require('google-closure-compiler-linux');
-  } catch (e) {
+  if (process.platform === 'linux' && ['x64','x32'].includes(process.arch)) {
+    try {
+      return require('google-closure-compiler-linux');
+    } catch (e) {
+    }
   }
 }
 


### PR DESCRIPTION
google-closure-compiler tries to use the native Linux build on every architecture, including ones for which there is no native build yet (e.g., arm64). We need to fall back to Java until a native build is available for the arm64 architecture.