### PR TITLE
Install upx in CI and minify the compiler for Linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,6 +92,12 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ env.NODE_VERSION }}
+      - name: Setup upx
+        run: |
+          UPX_VERSION=3.96
+          curl --fail --show-error --location --remote-name "https://github.com/upx/upx/releases/download/v$UPX_VERSION/upx-$UPX_VERSION-amd64_linux.tar.xz"
+          tar -xf upx-$UPX_VERSION-amd64_linux.tar.xz
+          mv ./upx-$UPX_VERSION-amd64_linux/upx /usr/local/bin/upx
       - name: Download compiler jar
         uses: actions/download-artifact@v2
         with:
@@ -120,6 +126,7 @@ jobs:
         run: |
           cp ../google-closure-compiler-java/compiler.jar compiler.jar
           yarn run build
+          upx compiler
       - name: Tests
         run: yarn workspaces run test --colors
       - name: Upload artifacts


### PR DESCRIPTION
This PR proposes upx compression of the compiler for Linux, due to the reasons reported at #186. The building workflows are [tested in my fork](https://github.com/itchyny/closure-compiler-npm/actions/runs/2063794971). Compared to the [latest build log](https://github.com/google/closure-compiler-npm/actions/runs/2058334239), the compiler size has been compressed from 307MiB to 86MiB.
Resolves #186.