### PR TITLE
Migrate to Bazelisk (fixes CI failure with HEAD compiler)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,10 +25,8 @@ jobs:
           java-version: 17
           java-package: jdk
           architecture: x64
-      - name: Setup Bazel
-        uses: jwlawson/actions-setup-bazel@v1
-        with:
-          bazel-version: '4.2.2'
+      - name: Setup Bazelisk
+        uses: bazelbuild/setup-bazelisk@v2
       - uses: actions/checkout@v2
         with:
           submodules: recursive

--- a/build-scripts/build_compiler.js
+++ b/build-scripts/build_compiler.js
@@ -44,7 +44,7 @@ async function main() {
   console.log(process.platform, process.arch, compilerVersion);
 
   const { exitCode } = await runCommand(
-    "bazel",
+    "bazelisk",
     [
       "build",
       "--color=yes",


### PR DESCRIPTION
Fixes #242 

- Example build where it chooses Bazel 4.2.2: https://github.com/google/closure-compiler-npm/runs/6707265420
- Example build where it chooses Bazel 5.1.1: https://github.com/google/closure-compiler-npm/runs/6707403758