### PR TITLE
Use a project local .npmrc file for publication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
           git add compiler
           yarn version --new-version ${{ github.event.inputs.COMPILER_VERSION_NUMBER }}.0.0
           git push origin master
-          git push origin v${{ github.event.inputs.COMPILER_VERSION_NUMBER }}
+          git push origin v${{ github.event.inputs.COMPILER_VERSION_NUMBER }}.0.0
       - name: Create GitHub Release
         run: curl \
           -X POST \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,9 +56,10 @@ jobs:
           git push origin master
           git push origin v${{ github.event.inputs.COMPILER_VERSION_NUMBER }}.0.0
       - name: Create GitHub Release
-        run: curl \
-          -X POST \
-          -H "Accept: application/vnd.github+json" \
-          -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-          https://api.github.com/repos/google/closure-compiler-npm/releases \
-          -d '{"tag_name":"v${{ github.event.inputs.COMPILER_VERSION_NUMBER }}.0.0","name":"${{ github.event.inputs.COMPILER_VERSION_NUMBER }}.0.0","body":"Closure-compiler ${{ github.event.inputs.COMPILER_VERSION_NUMBER }} release","draft":false,"prerelease":false,"generate_release_notes":false}'
+        run: |
+          curl \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            https://api.github.com/repos/google/closure-compiler-npm/releases \
+            -d '{"tag_name":"v${{ github.event.inputs.COMPILER_VERSION_NUMBER }}.0.0","name":"${{ github.event.inputs.COMPILER_VERSION_NUMBER }}.0.0","body":"Closure-compiler ${{ github.event.inputs.COMPILER_VERSION_NUMBER }} release","draft":false,"prerelease":false,"generate_release_notes":false}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,4 +61,4 @@ jobs:
           -H "Accept: application/vnd.github+json" \
           -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
           https://api.github.com/repos/google/closure-compiler-npm/releases \
-          -d '{"tag_name":"v${{ github.event.inputs.COMPILER_VERSION_NUMBER }}","name":"${{ github.event.inputs.COMPILER_VERSION_NUMBER }}.0.0","body":"Closure-compiler ${{ github.event.inputs.COMPILER_VERSION_NUMBER }} release","draft":false,"prerelease":false,"generate_release_notes":false}'
+          -d '{"tag_name":"v${{ github.event.inputs.COMPILER_VERSION_NUMBER }}.0.0","name":"${{ github.event.inputs.COMPILER_VERSION_NUMBER }}.0.0","body":"Closure-compiler ${{ github.event.inputs.COMPILER_VERSION_NUMBER }} release","draft":false,"prerelease":false,"generate_release_notes":false}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: write
+
 jobs:
   create-release:
     name: Create release
@@ -35,6 +38,7 @@ jobs:
           bazel-version: '4.2.2'
       - uses: actions/checkout@v2
         with:
+          refs: 'master'
           submodules: recursive
       - name: Set compiler submodule to release branch
         working-directory: compiler

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,15 +8,13 @@ on:
         required: true
         type: string
 
-permissions:
-  contents: write
-
 jobs:
   create-release:
     name: Create release
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      releases: write
     env:
       FORCE_COLOR: '1'
       NODE_VERSION: '18.x'
@@ -38,7 +36,7 @@ jobs:
           bazel-version: '4.2.2'
       - uses: actions/checkout@v2
         with:
-          refs: 'master'
+          refs: master
           submodules: recursive
       - name: Set compiler submodule to release branch
         working-directory: compiler
@@ -57,3 +55,10 @@ jobs:
           yarn version --new-version ${{ github.event.inputs.COMPILER_VERSION_NUMBER }}.0.0
           git push origin master
           git push origin v${{ github.event.inputs.COMPILER_VERSION_NUMBER }}
+      - name: Create GitHub Release
+        run: curl \
+          -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+          https://api.github.com/repos/google/closure-compiler-npm/releases \
+          -d '{"tag_name":"v${{ github.event.inputs.COMPILER_VERSION_NUMBER }}","name":"${{ github.event.inputs.COMPILER_VERSION_NUMBER }}.0.0","body":"Closure-compiler ${{ github.event.inputs.COMPILER_VERSION_NUMBER }} release","draft":false,"prerelease":false,"generate_release_notes":false}'

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ yarn-error.log
 /packages/google-closure-compiler-js/jscomp.js
 /temp
 /publish-log.txt
+.npmrc

--- a/build-scripts/publish.js
+++ b/build-scripts/publish.js
@@ -29,7 +29,7 @@ const path = require('path');
 const runCommand = require('./run-command');
 
 const packagesDirPath = path.resolve(__dirname, '../packages');
-const npmrcPath = path.resolve(process.env.HOME, '.npmrc');
+const npmrcPath = path.resolve(__dirname, '.npmrc');
 
 async function isPackageVersionPublished(packageName, version) {
   return fetch(`https://registry.npmjs.org/${encodeURI(packageName)}/${version}`)
@@ -54,26 +54,17 @@ async function getPackageInfo(packageDir) {
   };
 }
 
-let npmrcCleanupRequired = false;
 async function setupNpm() {
-  try {
-    await fs.stat(npmrcPath);
-    return;
-  } catch { }
-  // For npm publication to work, the NPM token must be stored in the .npmrc file in the user home directory
+  // For npm publication to work, the NPM token must be stored in the .npmrc file
   if (process.env.GITHUB_ACTIONS && process.env.NPM_TOKEN) {
     await fs.writeFile(
-        path.resolve(process.env.HOME, '.npmrc'),
-        `//registry.npmjs.org/:_authToken=${process.env.NPM_TOKEN}\n`,
+        npmrcPath,
+        `registry=https://registry.npmjs.org\n//registry.npmjs.org/:_authToken=${process.env.NPM_TOKEN}\n`,
         'utf8');
-    npmrcCleanupRequired = true;
   }
 }
 
 async function cleanupNpmrc() {
-  if (!npmrcCleanupRequired) {
-    return;
-  }
   await fs.unlink(npmrcPath);
 }
 


### PR DESCRIPTION
Updating npm publication to ensure that the correct registry is used.
Also update the release workflow to indicate that it needs access to push commits and tags back to the repository.