### PR TITLE
Add a --java-only flag to allow only the java tests to be run

### DIFF
--- a/packages/google-closure-compiler/test/cli.js
+++ b/packages/google-closure-compiler/test/cli.js
@@ -26,6 +26,12 @@ const should = require('should');
 const runCommand = require('../../../build-scripts/run-command');
 require('mocha');
 
+const javaOnly = process.argv.find((arg) => arg == '--java-only');
+const platforms = ['java'];
+if (!javaOnly) {
+  platforms.push('native');
+}
+
 process.on('unhandledRejection', e => { throw e; });
 
 describe('command line interface', function() {
@@ -37,21 +43,23 @@ describe('command line interface', function() {
     cliPath = `node ${cliPath}`;
   }
 
-  it('chooses an acceptable platform automatically', done => {
-    function complete(arg) {
-      should(arg).not.be.instanceof(Error);
-      const {stdout, sderr, exitCode} = arg;
-      should(exitCode).equal(0);
-      should(stdout.length).above(0);
-      done();
-    }
+  if (!javaOnly) {
+    it('chooses an acceptable platform automatically', done => {
+      function complete(arg) {
+        should(arg).not.be.instanceof(Error);
+        const {stdout, sderr, exitCode} = arg;
+        should(exitCode).equal(0);
+        should(stdout.length).above(0);
+        done();
+      }
 
-    runCommand(`${cliPath} --js test/fixtures/one.js`, {stdio: 'pipe'})
-      .then(complete)
-      .catch(complete);
-  });
+      runCommand(`${cliPath} --js test/fixtures/one.js`, {stdio: 'pipe'})
+          .then(complete)
+          .catch(complete);
+    });
+  }
 
-  ['java', 'native'].forEach(platform => {
+  platforms.forEach(platform => {
     describe(`${platform} version`, function() {
       it('--help flag', done => {
         function complete(arg) {

--- a/packages/google-closure-compiler/test/grunt.js
+++ b/packages/google-closure-compiler/test/grunt.js
@@ -30,6 +30,12 @@ require('mocha');
 
 process.on('unhandledRejection', e => { throw e; });
 
+const javaOnly = process.argv.find((arg) => arg == '--java-only');
+const platforms = ['java'];
+if (!javaOnly) {
+  platforms.push('native');
+}
+
 const assertNoError = new should.Assertion('grunt');
 assertNoError.params = {
   operator: 'should not fail with an error',
@@ -125,7 +131,7 @@ describe('grunt-google-closure-compiler', function() {
     Object.defineProperty(ClosureCompiler.prototype, 'run', originalCompilerRunMethod);
   });
 
-  ['java', 'native'].forEach(platform => {
+  platforms.forEach(platform => {
     describe(`${platform} version`, function() {
       let closureCompiler;
       this.slow(10000);

--- a/packages/google-closure-compiler/test/gulp.js
+++ b/packages/google-closure-compiler/test/gulp.js
@@ -33,6 +33,12 @@ const streamFilter = require('gulp-filter');
 
 require('mocha');
 
+const javaOnly = process.argv.find((arg) => arg == '--java-only');
+const platforms = ['java'];
+if (!javaOnly) {
+  platforms.push('native');
+}
+
 process.on('unhandledRejection', e => { throw e; });
 
 describe('gulp-google-closure-compiler', function() {
@@ -58,7 +64,7 @@ describe('gulp-google-closure-compiler', function() {
     Object.defineProperty(ClosureCompiler.prototype, 'run', originalCompilerRunMethod);
   });
 
-  ['java', 'native'].forEach(platform => {
+  platforms.forEach(platform => {
     describe(`${platform} version`, function() {
       const closureCompiler = compilerPackage.gulp();
 


### PR DESCRIPTION
Supports testing the npm package in the main compiler CI pipeline