### PR TITLE
When a new release is created, trigger an immediate build and publish

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,8 @@ name: Build CI
 on:
   push:
     branches: [ master ]
+  workflow_call:
+    branches: [ master ]
   pull_request:
     branches: [ master ]
   schedule:
@@ -273,7 +275,7 @@ jobs:
   publish-packages:
     name: Publish Packages
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'push' }}
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_call' }}
     env:
       NODE_VERSION: '18.x'
       COMPILER_NIGHTLY: ${{ github.event_name == 'schedule' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,7 @@ name: Build CI
 on:
   push:
     branches: [ master ]
-  workflow_call:
-    branches: [ master ]
+  workflow_call: {}
   pull_request:
     branches: [ master ]
   schedule:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,3 +61,5 @@ jobs:
             -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
             https://api.github.com/repos/google/closure-compiler-npm/releases \
             -d '{"tag_name":"v${{ github.event.inputs.COMPILER_VERSION_NUMBER }}.0.0","name":"${{ github.event.inputs.COMPILER_VERSION_NUMBER }}.0.0","body":"Closure-compiler ${{ github.event.inputs.COMPILER_VERSION_NUMBER }} release","draft":false,"prerelease":false,"generate_release_notes":true}'
+      - name: Trigger Build and Publish
+        uses: ./.github/workflows/build.yml


### PR DESCRIPTION
When new compiler releases are created, currently we have to manually trigger publication with a separate empty commit. This is because GitHub prevents push events in a workflow from automatically triggering other workflows to prevent recursive runs.

Instead, manually call the standard build CI workflow so that a new compiler release is immediately published.

Unfortunately there's no way to test this before a release is actually created.