### PR TITLE
Modify workflow call syntax

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,5 +61,7 @@ jobs:
             -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
             https://api.github.com/repos/google/closure-compiler-npm/releases \
             -d '{"tag_name":"v${{ github.event.inputs.COMPILER_VERSION_NUMBER }}.0.0","name":"${{ github.event.inputs.COMPILER_VERSION_NUMBER }}.0.0","body":"Closure-compiler ${{ github.event.inputs.COMPILER_VERSION_NUMBER }} release","draft":false,"prerelease":false,"generate_release_notes":true}'
-      - name: Trigger Build and Publish
-        uses: ./.github/workflows/build.yml
+  trigger-publication:
+    name: Trigger Build and Publish
+    needs: create-release
+    uses: ./.github/workflows/build.yml


### PR DESCRIPTION
Followup to #258

The release job failed with the following error:

```
Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '/home/runner/work/closure-compiler-npm/closure-compiler-npm/.github/workflows/build.yml'.
```

Updates the syntax slightly to work around this. Won't be testable until the next release though.