### PR TITLE
Update action versions to latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       FORCE_COLOR: '1'
     steps:
       - name: Setup Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: adopt-hotspot
           java-version: 17
@@ -28,7 +28,7 @@ jobs:
           architecture: x64
       - name: Setup Bazelisk
         uses: bazelbuild/setup-bazelisk@v2
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
       - name: Fetch submodule tags
@@ -45,7 +45,7 @@ jobs:
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
       - name: Yarn and maven cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -58,12 +58,12 @@ jobs:
       - name: Tests
         run: node_modules/.bin/mocha --colors
       - name: Upload contrib folder
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Contrib folder
           path: compiler/contrib
       - name: Upload compiler jar
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Compiler.jar
           path: packages/google-closure-compiler-java/compiler.jar
@@ -78,13 +78,13 @@ jobs:
       FORCE_COLOR: '1'
     steps:
       - name: Setup Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: adopt-hotspot
           java-version: 17
           java-package: jdk
           architecture: x64
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v3
         with:
@@ -115,7 +115,7 @@ jobs:
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
       - name: Cache yarn
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -133,7 +133,7 @@ jobs:
       - name: Tests
         run: yarn workspaces run test --colors
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Linux image
           path: packages/google-closure-compiler-linux/compiler
@@ -148,13 +148,13 @@ jobs:
       FORCE_COLOR: '1'
     steps:
       - name: Setup Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: adopt-hotspot
           java-version: 17
           java-package: jdk
           architecture: x64
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v3
         with:
@@ -181,7 +181,7 @@ jobs:
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
       - name: Cache yarn
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -199,7 +199,7 @@ jobs:
       - name: Tests
         run: yarn workspaces run test --colors
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: MacOS image
           path: packages/google-closure-compiler-osx/compiler
@@ -214,13 +214,13 @@ jobs:
       FORCE_COLOR: '1'
     steps:
       - name: Setup Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: adopt-hotspot
           java-version: 17
           java-package: jdk
           architecture: x64
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v3
         with:
@@ -245,7 +245,7 @@ jobs:
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
       - name: Cache yarn
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -265,7 +265,7 @@ jobs:
           echo "Running Tests"
           yarn workspaces run test --colors
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Windows image
           path: packages/google-closure-compiler-windows/compiler.exe
@@ -285,7 +285,7 @@ jobs:
       - build-macos
       - build-windows
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v3
         with:
@@ -325,7 +325,7 @@ jobs:
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
       - name: Cache yarn
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Setup Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: adopt-hotspot
           java-version: 17
@@ -33,7 +33,7 @@ jobs:
         uses: jwlawson/actions-setup-bazel@v1
         with:
           bazel-version: '4.2.2'
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
       - name: Set compiler submodule to release branch


### PR DESCRIPTION
Update GitHub actions to latest version to avoid node deprecation warnings. See https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/