### PR TITLE
Switch the event name allowed to publish to `workflow_dispatch`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -274,7 +274,7 @@ jobs:
   publish-packages:
     name: Publish Packages
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_call' }}
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
     env:
       NODE_VERSION: '18.x'
       COMPILER_NIGHTLY: ${{ github.event_name == 'schedule' }}


### PR DESCRIPTION
While the trigger is listed as `workflow_call`, apparently the inherited event retains the original `workflow_dispatch` name. See https://github.com/github/docs/issues/16515

Hopefully fixes the release workflow to automatically publish to NPM.