### PR TITLE
Update confusing statement about JS-native version

### DIFF
--- a/packages/google-closure-compiler/README.md
+++ b/packages/google-closure-compiler/README.md
@@ -7,8 +7,7 @@ This repository tracks issues related to the publication to npmjs.org and associ
 Any bugs not related to the plugins themselves should be reported to the
 [main repository](https://github.com/google/closure-compiler/).
 
-**The JS version of closure-compiler is no longer supported or maintained.**  
-[Read why](https://github.com/google/closure-compiler-npm/blob/master/packages/google-closure-compiler-js/readme.md)
+**Note that the installed binary is not actually JavaScript, but native binary or Java jar file depending on the local system.** 
 
 ## Getting Started
 If you are new to [Closure-Compiler](https://developers.google.com/closure/compiler/), make


### PR DESCRIPTION
I made this change in response to https://github.com/google/closure-compiler/discussions/4003