### PR TITLE
Support multiple libc versions by dynamically linking against libc

### DIFF
--- a/build-scripts/graal.js
+++ b/build-scripts/graal.js
@@ -33,6 +33,7 @@ process.on('unhandledRejection', error => {
 });
 
 const NATIVE_IMAGE_BUILD_ARGS = [
+  '-H:+StaticExecutableWithDynamicLibC',
   '-H:+ReportUnsupportedElementsAtRuntime',
   '-H:IncludeResourceBundles=org.kohsuke.args4j.Messages',
   '-H:IncludeResourceBundles=org.kohsuke.args4j.spi.Messages',

--- a/build-scripts/graal.js
+++ b/build-scripts/graal.js
@@ -33,7 +33,6 @@ process.on('unhandledRejection', error => {
 });
 
 const NATIVE_IMAGE_BUILD_ARGS = [
-  '-H:+StaticExecutableWithDynamicLibC',
   '-H:+ReportUnsupportedElementsAtRuntime',
   '-H:IncludeResourceBundles=org.kohsuke.args4j.Messages',
   '-H:IncludeResourceBundles=org.kohsuke.args4j.spi.Messages',
@@ -56,6 +55,11 @@ const NATIVE_IMAGE_BUILD_ARGS = [
   '-jar',
   path.resolve(process.cwd(), 'compiler.jar')
 ];
+
+if (process.platform !== 'darwin') {
+  // MacOS does not support building statically linked images
+  NATIVE_IMAGE_BUILD_ARGS.unshift('-H:+StaticExecutableWithDynamicLibC');
+}
 
 runCommand(`native-image${process.platform === 'win32' ? '.cmd' : ''}`, NATIVE_IMAGE_BUILD_ARGS)
     .catch(e => {


### PR DESCRIPTION
Fixes #272 

See https://www.graalvm.org/22.0/reference-manual/native-image/StaticImages/