### PR TITLE
Switch the linux graal build runner for better GLIBC compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,10 +68,12 @@ jobs:
           path: packages/google-closure-compiler-java/compiler.jar
 
   # Build the native image on Linux
+  # The runner image determines GLIBC compatibility and should not be changed without
+  # understanding the impact. See https://github.com/google/closure-compiler-npm/issues/280
   build-linux:
     name: Build Linux Native Image
     needs: build-compiler
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       NODE_VERSION: '14.x'
       FORCE_COLOR: '1'


### PR DESCRIPTION
Allows a wider range of GLIBC versions. Fixes #280.