### PR TITLE
Revert "Support multiple libc versions by dynamically linking against libc"

### DIFF
--- a/build-scripts/graal.js
+++ b/build-scripts/graal.js
@@ -56,11 +56,6 @@ const NATIVE_IMAGE_BUILD_ARGS = [
   path.resolve(process.cwd(), 'compiler.jar')
 ];
 
-if (process.platform !== 'darwin') {
-  // MacOS does not support building statically linked images
-  NATIVE_IMAGE_BUILD_ARGS.unshift('-H:+StaticExecutableWithDynamicLibC');
-}
-
 runCommand(`native-image${process.platform === 'win32' ? '.cmd' : ''}`, NATIVE_IMAGE_BUILD_ARGS)
     .catch(e => {
       console.error(e);


### PR DESCRIPTION
Reverts google/closure-compiler-npm#273

Compatibility for GLIBC was addressed in #280 so we can now go back to static linking.