### PR TITLE
Manually run the Build CI as part of the release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build CI
 on:
   push:
     branches: [ master ]
-  workflow_call: {}
+  workflow_dispatch: {}
   pull_request:
     branches: [ master ]
   schedule:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,3 @@ jobs:
             -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
             https://api.github.com/repos/google/closure-compiler-npm/releases \
             -d '{"tag_name":"v${{ github.event.inputs.COMPILER_VERSION_NUMBER }}.0.0","name":"${{ github.event.inputs.COMPILER_VERSION_NUMBER }}.0.0","body":"Closure-compiler ${{ github.event.inputs.COMPILER_VERSION_NUMBER }} release","draft":false,"prerelease":false,"generate_release_notes":true}'
-  trigger-publication:
-    name: Trigger Build and Publish
-    needs: create-release
-    uses: google/closure-compiler-npm/.github/workflows/build.yml@master

--- a/deployments.md
+++ b/deployments.md
@@ -7,7 +7,8 @@
  1. Run the [Compiler release workflow](https://github.com/google/closure-compiler-npm/actions/workflows/release.yml)
      * For the `COMPILER_VERSION_NUMBER` input, use the actual version number here without the `v`.
  2. Verify the workflow runs successfully. It will push the release commit and tag.
- 3. Verify the Build CI workflow triggered from the commit builds and publishes the release successfully.
+ 3. Manually run the [Compiler Build CI workflow](https://github.com/google/closure-compiler-npm/actions/workflows/build.yml)
+ 4. Verify the new version published to npm.
 
 ## Deploying changes to the package CLIs or plugins
 


### PR DESCRIPTION
Since GitHub actions use the same commit as part of any re-used workflow, the new compiler version is not getting published. Require the Build CI action to be manually run after the release commit is created.