### PR TITLE
Update Graal to 22.3.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
       - uses: graalvm/setup-graalvm@v1
         with:
-          version: '22.3.0'
+          version: '22.3.2'
           java-version: '17'
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -161,7 +161,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
       - uses: graalvm/setup-graalvm@v1
         with:
-          version: '22.3.0'
+          version: '22.3.2'
           java-version: '17'
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -227,7 +227,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
       - uses: graalvm/setup-graalvm@v1
         with:
-          version: '22.3.0'
+          version: '22.3.2'
           java-version: '17'
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Minor version update. Graal release notes indicate that the underlying JDK has security fixes.