### PR TITLE
Turn nightly builds back on

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -344,5 +344,4 @@ jobs:
       - name: Configure yarn
         run: yarn config set registry https://registry.npmjs.org/
       - name: Publish packages to npm
-        #run: yarn publish-packages
-        run: echo "Skipping yarn publish-packages step"
+        run: yarn publish-packages


### PR DESCRIPTION
Now that the uber-jars are fixed, we should be able to turn these back on.