### PR TITLE
Add reflection protection for GRAAL to prevent runtime exceptions

### DIFF
--- a/build-scripts/reflection-config.json
+++ b/build-scripts/reflection-config.json
@@ -204,6 +204,11 @@
     "allPublicFields" : true
   },
   {
+    "name": "com.google.javascript.jscomp.ConformanceConfig$LibraryLevelNonAllowlistedConformanceViolationsBehavior",
+    "allPublicMethods" : true,
+    "allPublicFields" : true
+  },
+  {
     "name" : "com.google.javascript.jscomp.ConformanceRules",
     "allDeclaredMethods" : true,
     "allDeclaredFields" : true,


### PR DESCRIPTION
Conformance configurations trigger runtime exceptions due to missing methods and fields

Fixes #316 