### PR TITLE
Use more specific patterns for matching included resources

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,9 +43,6 @@ jobs:
         with:
           submodules: recursive
           ref: ${{ inputs.release-tag || '' }}
-      - name: Fetch submodule tags
-        working-directory: compiler
-        run: git fetch --tags https://github.com/google/closure-compiler.git
       - name: Get yarn cache directory path
         run: echo "yarn_cache_dir=$(yarn cache dir)" >> $GITHUB_ENV
       - name: Yarn and maven cache
@@ -109,12 +106,6 @@ jobs:
           distribution: 'graalvm-community'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           native-image-job-reports: 'true'
-      - name: Setup upx
-        run: |
-          UPX_VERSION=5.0.0
-          curl --fail --show-error --location --remote-name "https://github.com/upx/upx/releases/download/v$UPX_VERSION/upx-$UPX_VERSION-amd64_linux.tar.xz"
-          tar -xf upx-$UPX_VERSION-amd64_linux.tar.xz
-          mv ./upx-$UPX_VERSION-amd64_linux/upx /usr/local/bin/upx
       - name: Download compiler jar
         uses: actions/download-artifact@v4
         with:
@@ -147,7 +138,6 @@ jobs:
         run: |
           cp ../google-closure-compiler-java/compiler.jar compiler.jar
           yarn run build
-          upx compiler
       - name: Tests
         run: yarn workspaces run test --color
       - name: Upload artifacts
@@ -187,12 +177,6 @@ jobs:
           distribution: 'graalvm-community'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           native-image-job-reports: 'true'
-      - name: Setup upx
-        run: |
-          UPX_VERSION=5.0.0
-          curl --fail --show-error --location --remote-name "https://github.com/upx/upx/releases/download/v$UPX_VERSION/upx-$UPX_VERSION-arm64_linux.tar.xz"
-          tar -xf upx-$UPX_VERSION-arm64_linux.tar.xz
-          mv ./upx-$UPX_VERSION-arm64_linux/upx /usr/local/bin/upx
       - name: Download compiler jar
         uses: actions/download-artifact@v4
         with:
@@ -225,7 +209,6 @@ jobs:
         run: |
           cp ../google-closure-compiler-java/compiler.jar compiler.jar
           yarn run build
-          upx compiler
       - name: Tests
         run: yarn workspaces run test --color
       - name: Upload artifacts
@@ -263,9 +246,6 @@ jobs:
           distribution: 'graalvm-community'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           native-image-job-reports: 'true'
-#        # See https://github.com/google/closure-compiler-npm/issues/265
-#      - name: Install upx
-#        run: brew install upx
       - name: Download compiler jar
         uses: actions/download-artifact@v4
         with:
@@ -298,7 +278,6 @@ jobs:
         run: |
           cp ../google-closure-compiler-java/compiler.jar compiler.jar
           yarn run build
-#          upx compiler
       - name: Tests
         run: yarn workspaces run test --color
       - name: Upload artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,9 @@ jobs:
         with:
           submodules: recursive
           ref: ${{ inputs.release-tag || '' }}
+      - name: Fetch submodule tags
+        working-directory: compiler
+        run: git fetch --tags https://github.com/google/closure-compiler.git
       - name: Get yarn cache directory path
         run: echo "yarn_cache_dir=$(yarn cache dir)" >> $GITHUB_ENV
       - name: Yarn and maven cache

--- a/build-scripts/graal.js
+++ b/build-scripts/graal.js
@@ -36,7 +36,6 @@ process.on('unhandledRejection', error => {
 
 const NATIVE_IMAGE_BUILD_ARGS = [
   '-H:+UnlockExperimentalVMOptions',
-  '-H:+ReportUnsupportedElementsAtRuntime',
   '-H:IncludeResourceBundles=org.kohsuke.args4j.Messages',
   '-H:IncludeResourceBundles=org.kohsuke.args4j.spi.Messages',
   '-H:IncludeResourceBundles=com.google.javascript.jscomp.parsing.ParserConfig',
@@ -47,6 +46,7 @@ const NATIVE_IMAGE_BUILD_ARGS = [
   '-H:IncludeResources=com\/google\/javascript\/.*\.txt',
   '-H:IncludeResources=com\/google\/javascript\/.*\.typedast',
   '-H:+ReportExceptionStackTraces',
+  '--report-unsupported-elements-at-runtime',
   '--initialize-at-build-time',
   '--color=always',
   '-jar',

--- a/build-scripts/graal.js
+++ b/build-scripts/graal.js
@@ -34,18 +34,6 @@ process.on('unhandledRejection', error => {
   process.exit(1);
 });
 
-const windowsPathReplacer = (match) => {
-  if (process.platform === 'win32') {
-    // Escape the '|' character in a  windows batch command
-    // See https://stackoverflow.com/a/16018942/1211524
-    if (match === '|') {
-      return '^^^|';
-    }
-    return `^${match}`;
-  }
-  return '|';
-};
-
 const NATIVE_IMAGE_BUILD_ARGS = [
   '-H:+ReportUnsupportedElementsAtRuntime',
   '-H:IncludeResourceBundles=org.kohsuke.args4j.Messages',
@@ -53,10 +41,10 @@ const NATIVE_IMAGE_BUILD_ARGS = [
   '-H:IncludeResourceBundles=com.google.javascript.jscomp.parsing.ParserConfig',
   '-H:+AllowIncompleteClasspath',
   `-H:ReflectionConfigurationFiles=${path.resolve(__dirname, 'reflection-config.json')}`,
-  '-H:IncludeResources=externs\.zip'.replace(/[\|\(\)]/g, windowsPathReplacer),
-  '-H:IncludeResources=com\/google\/javascript\/.*\.js'.replace(/[\|\(\)]/g, windowsPathReplacer),
-  '-H:IncludeResources=com\/google\/javascript\/.*\.txt'.replace(/[\|\(\)]/g, windowsPathReplacer),
-  '-H:IncludeResources=com\/google\/javascript\/.*\.typedast'.replace(/[\|\(\)]/g, windowsPathReplacer),
+  '-H:IncludeResources=externs\.zip',
+  '-H:IncludeResources=com\/google\/javascript\/.*\.js',
+  '-H:IncludeResources=com\/google\/javascript\/.*\.txt',
+  '-H:IncludeResources=com\/google\/javascript\/.*\.typedast',
   '-H:+ReportExceptionStackTraces',
   '--initialize-at-build-time',
   '--color=always',

--- a/build-scripts/graal.js
+++ b/build-scripts/graal.js
@@ -35,6 +35,7 @@ process.on('unhandledRejection', error => {
 });
 
 const NATIVE_IMAGE_BUILD_ARGS = [
+  '-H:+UnlockExperimentalVMOptions',
   '-H:+ReportUnsupportedElementsAtRuntime',
   '-H:IncludeResourceBundles=org.kohsuke.args4j.Messages',
   '-H:IncludeResourceBundles=org.kohsuke.args4j.spi.Messages',


### PR DESCRIPTION
Avoids including hundreds of MBs of javadoc in the native image binaries

This was diagnosed by using the latest version of GraalVM and using the `-H:+GenerateEmbeddedResourcesFile` flag.