### PR TITLE
On linux, statically link all libraries including GLIBC

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,6 +89,8 @@ jobs:
       NODE_VERSION: '20.x'
       FORCE_COLOR: '1'
     steps:
+      - name: Install musl
+        run: sudo apt-get install -y musl
       - name: Setup Java
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
@@ -160,6 +162,8 @@ jobs:
       NODE_VERSION: '20.x'
       FORCE_COLOR: '1'
     steps:
+      - name: Install musl
+        run: sudo apt-get install -y musl
       - name: Setup Java
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:

--- a/build-scripts/graal.js
+++ b/build-scripts/graal.js
@@ -57,8 +57,15 @@ const NATIVE_IMAGE_BUILD_ARGS = [
 ];
 
 const spawnOpts = {};
-if (process.platform === 'win32') {
-  spawnOpts.shell = true;
+switch (process.platform) {
+  case 'win32':
+    spawnOpts.shell = true;
+    break;
+  case 'linux':
+    // On linux, statically link all libraries. Allows usage on systems
+    // which are missing or have incompatible versions of GLIBC
+    NATIVE_IMAGE_BUILD_ARGS.unshift('--static');
+    break;
 }
 
 runCommand(`native-image${process.platform === 'win32' ? '.cmd' : ''}`, NATIVE_IMAGE_BUILD_ARGS, spawnOpts)

--- a/build-scripts/graal.js
+++ b/build-scripts/graal.js
@@ -63,8 +63,9 @@ switch (process.platform) {
     break;
   case 'linux':
     // On linux, statically link all libraries. Allows usage on systems
-    // which are missing or have incompatible versions of GLIBC
-    NATIVE_IMAGE_BUILD_ARGS.unshift('--static');
+    // which are missing or have incompatible versions of GLIBC.
+    // See https://www.graalvm.org/latest/reference-manual/native-image/guides/build-static-executables/
+    NATIVE_IMAGE_BUILD_ARGS.unshift('--static', '--libc=musl');
     break;
 }
 


### PR DESCRIPTION
Currently, GLIBC must not only be installed on the host, but has to be compatible with the version the image was built with. Static linking avoids both of these issues at the cost of a slightly larger image size.

Example GLIBC incompatible error:

```text
Error writing to stdin of the compiler. write EPIPE /node_modules/google-closure-compiler-linux/compiler: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found
```